### PR TITLE
Add `best::reflect` and the other trappings of a `#[derive]`-like reflection 

### DIFF
--- a/best/base/BUILD
+++ b/best/base/BUILD
@@ -3,6 +3,10 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
   name = "fwd",
   hdrs = ["fwd.h"],
+  deps = [
+    "//best/meta:taxonomy",
+    "//best/meta:tags",
+  ]
 )
 
 cc_library(

--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -87,6 +87,7 @@ class track_location;
 struct empty;
 
 // best/meta/reflect.h
+template <typename>
 class mirror;
 template <auto&>
 class reflected_field;

--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -24,6 +24,9 @@
 
 #include <cstdint>
 
+#include "best/meta/tags.h"
+#include "best/meta/taxonomy.h"
+
 //! Forward declarations of all types in best that can be forward-declared.
 //!
 //! This header is used both for breaking dependency cycles within best, and
@@ -67,6 +70,14 @@ class pun;
 // best/container/span.h
 // template <typename, best::option<size_t>>
 // class span;
+
+// best/func/tap.h
+template <typename, typename>
+class tap;
+template <typename Cb>
+tap(Cb&&) -> tap<tags_internal_do_not_use::ctad_guard, best::as_auto<Cb>>;
+template <typename Cb>
+tap(best::bind_t, Cb&&) -> tap<tags_internal_do_not_use::ctad_guard, Cb&&>;
 
 // best/log/location.h
 template <typename>

--- a/best/container/BUILD
+++ b/best/container/BUILD
@@ -166,6 +166,7 @@ cc_library(
   ],
   deps = [
     ":option",
+    ":result",
     "//best/memory:bytes",
   ],
 )

--- a/best/container/internal/row.h
+++ b/best/container/internal/row.h
@@ -105,15 +105,15 @@ inline constexpr auto lookup =
 
 template <typename K, typename... Ts, const auto& lut = lookup<Ts...>,
           size_t count = lut.template count<K>()>
-inline constexpr auto apply_lookup(auto cb) {
+inline constexpr auto do_lookup() {
   if constexpr (count == 0) {
-    return best::call(cb);
+    return best::vals<>;
   } else {
     const size_t(&table)[sizeof...(Ts)] =
         static_cast<const entry<sizeof...(Ts), K>&>(lut).table;
 
     return [&]<size_t... i>(std::index_sequence<i...>) {
-      return best::call(cb, best::index<table[i]>...);
+      return best::vals<table[i]...>;
     }(std::make_index_sequence<count>{});
   }
 }

--- a/best/container/row.h
+++ b/best/container/row.h
@@ -210,6 +210,14 @@ class row final
   /// Returns whether this is the empty row `best::row<>`.
   constexpr static bool is_empty() { return types.size() == 0; }
 
+  /// # `row::as_ref()`
+  ///
+  /// Creates a new row of references.
+  constexpr best::row<best::as_ref<const Elems>...> as_ref() const&;
+  constexpr best::row<best::as_ref<Elems>...> as_ref() &;
+  constexpr best::row<best::as_rref<const Elems>...> as_ref() const&&;
+  constexpr best::row<best::as_rref<Elems>...> as_ref() &&;
+
   /// # `row[index<n>]`, `row[best::values<bounds{...}>]`
   ///
   /// Returns a reference to the `n`th element, or a subrange as a row (values

--- a/best/container/row.h
+++ b/best/container/row.h
@@ -68,10 +68,10 @@ struct args final {
         [](auto&&... args) { return T(BEST_FWD(args)...); });
   }
 
-  friend void BestFmt(auto& fmt, const args& row)
-    requires requires { (fmt.format(row.row)); }
+  friend void BestFmt(auto& fmt, const args& args)
+    requires requires { (fmt.format(args.row)); }
   {
-    fmt.format(row);
+    fmt.format(args.row);
   }
 
   friend constexpr void BestFmtQuery(auto& query, args*) {
@@ -212,7 +212,7 @@ class row final
 
   /// # `row::as_ref()`
   ///
-  /// Creates a new row of references.
+  /// Creates a row of references to the elements of this row.
   constexpr best::row<best::as_ref<const Elems>...> as_ref() const&;
   constexpr best::row<best::as_ref<Elems>...> as_ref() &;
   constexpr best::row<best::as_rref<const Elems>...> as_ref() const&&;
@@ -276,11 +276,18 @@ class row final
   /// type, or which have a member alias named `BestRowKey` of that type. They
   /// are returned in the order they occur in this row.
   // clang-format off
-  template <typename T> constexpr decltype(auto) select(best::tlist<T> idx = {}) const&;
-  template <typename T> constexpr decltype(auto) select(best::tlist<T> idx = {}) & ;
-  template <typename T> constexpr decltype(auto) select(best::tlist<T> idx = {}) const&& ; 
-  template <typename T> constexpr decltype(auto) select(best::tlist<T> idx = {}) &&;
+  template <typename T> constexpr auto select(best::tlist<T> idx = {}) const&;
+  template <typename T> constexpr auto select(best::tlist<T> idx = {}) & ;
+  template <typename T> constexpr auto select(best::tlist<T> idx = {}) const&&; 
+  template <typename T> constexpr auto select(best::tlist<T> idx = {}) &&;
   // clang-format on
+
+  /// # `row::select_indices()`
+  ///
+  /// Returns a `best::vlist` of the indices of the elements that
+  /// `row::select()` returns.
+  template <typename T>
+  static constexpr auto select_indices(best::tlist<T> idx = {});
 
   /// # `row::first()`, `row::second()`, `row::last()`
   ///
@@ -567,6 +574,30 @@ constexpr auto row<A...>::as_args() && {
 }
 
 template <typename... A>
+constexpr best::row<best::as_ref<const A>...> row<A...>::as_ref() const& {
+  apply([](auto&&... args) {
+    best::row<best::as_ref<const A>...>(BEST_FWD(args)...);
+  });
+}
+template <typename... A>
+constexpr best::row<best::as_ref<A>...> row<A...>::as_ref() & {
+  apply(
+      [](auto&&... args) { best::row<best::as_ref<A>...>(BEST_FWD(args)...); });
+}
+template <typename... A>
+constexpr best::row<best::as_rref<const A>...> row<A...>::as_ref() const&& {
+  BEST_MOVE(*this).apply([](auto&&... args) {
+    best::row<best::as_rref<const A>...>(BEST_FWD(args)...);
+  });
+}
+template <typename... A>
+constexpr best::row<best::as_rref<A>...> row<A...>::as_ref() && {
+  BEST_MOVE(*this).apply([](auto&&... args) {
+    best::row<best::as_rref<A>...>(BEST_FWD(args)...);
+  });
+}
+
+template <typename... A>
 template <size_t n>
 constexpr row<A...>::cref<n> row<A...>::operator[](
     best::index_t<n> idx) const& {
@@ -774,35 +805,29 @@ constexpr auto row<A...>::operator+(best::is_row auto&& that) && {
 
 template <typename... A>
 template <typename T>
-constexpr decltype(auto) row<A...>::select(best::tlist<T> idx) const& {
-  return row_internal::apply_lookup<T, A...>(
-      [&]<size_t... i>(index_t<i>... idx) {
-        return best::row<cref<i>...>(at(idx)...);
-      });
+constexpr auto row<A...>::select(best::tlist<T> idx) const& {
+  return gather(select_indices(idx));
 }
 template <typename... A>
 template <typename T>
-constexpr decltype(auto) row<A...>::select(best::tlist<T> idx) & {
-  return row_internal::apply_lookup<T, A...>(
-      [&]<size_t... i>(index_t<i>... idx) {
-        return best::row<ref<i>...>(at(idx)...);
-      });
+constexpr auto row<A...>::select(best::tlist<T> idx) & {
+  return gather(select_indices(idx));
 }
 template <typename... A>
 template <typename T>
-constexpr decltype(auto) row<A...>::select(best::tlist<T> idx) const&& {
-  return row_internal::apply_lookup<T, A...>(
-      [&]<size_t... i>(index_t<i>... idx) {
-        return best::row<crref<i>...>(BEST_MOVE(*this).at(idx)...);
-      });
+constexpr auto row<A...>::select(best::tlist<T> idx) const&& {
+  return BEST_MOVE(*this).gather(select_indices(idx));
 }
 template <typename... A>
 template <typename T>
-constexpr decltype(auto) row<A...>::select(best::tlist<T> idx) && {
-  return row_internal::apply_lookup<T, A...>(
-      [&]<size_t... i>(index_t<i>... idx) {
-        return best::row<rref<i>...>(BEST_MOVE(*this).at(idx)...);
-      });
+constexpr auto row<A...>::select(best::tlist<T> idx) && {
+  return BEST_MOVE(*this).gather(select_indices(idx));
+}
+
+template <typename... A>
+template <typename T>
+constexpr auto row<A...>::select_indices(best::tlist<T> idx) {
+  return row_internal::do_lookup<T, A...>();
 }
 
 // XXX: This code tickles a clang-format bug.
@@ -1072,7 +1097,7 @@ BEST_ROW_MUST_USE(update)
 constexpr auto row<A...>::update(auto&& that, best::index_t<n>) const& {
   return splice(best::types<best::as_auto<decltype(that)>>,
                 best::row(best::bind, BEST_FWD(that)),
-                best::vals<bounds{.start = n, .count = 0}>);
+                best::vals<bounds{.start = n, .count = 1}>);
 }
 template <typename... A>
 template <size_t n>

--- a/best/container/span_sort.h
+++ b/best/container/span_sort.h
@@ -30,13 +30,14 @@
 
 namespace best {
 template <best::is_object T, best::option<size_t> n>
-void span<T, n>::sort() const
+constexpr void span<T, n>::sort() const
   requires best::comparable<T> && (!is_const)
 {
   std::sort(data().raw(), data().raw() + size());
 }
 template <best::is_object T, best::option<size_t> n>
-void span<T, n>::sort(best::callable<void(const T&)> auto&& get_key) const
+constexpr void span<T, n>::sort(
+    best::callable<void(const T&)> auto&& get_key) const
   requires(!is_const)
 {
   std::sort(data().raw(), data().raw() + size(), [&](auto& a, auto& b) {
@@ -44,7 +45,7 @@ void span<T, n>::sort(best::callable<void(const T&)> auto&& get_key) const
   });
 }
 template <best::is_object T, best::option<size_t> n>
-void span<T, n>::sort(
+constexpr void span<T, n>::sort(
     best::callable<best::partial_ord(const T&, const T&)> auto&& get_key) const
   requires(!is_const)
 {
@@ -53,13 +54,13 @@ void span<T, n>::sort(
   });
 }
 template <best::is_object T, best::option<size_t> n>
-void span<T, n>::stable_sort() const
+constexpr void span<T, n>::stable_sort() const
   requires best::comparable<T> && (!is_const)
 {
   std::stable_sort(data().raw(), data().raw() + size());
 }
 template <best::is_object T, best::option<size_t> n>
-void span<T, n>::stable_sort(
+constexpr void span<T, n>::stable_sort(
     best::callable<void(const T&)> auto&& get_key) const
   requires(!is_const)
 {
@@ -68,7 +69,7 @@ void span<T, n>::stable_sort(
   });
 }
 template <best::is_object T, best::option<size_t> n>
-void span<T, n>::stable_sort(
+constexpr void span<T, n>::stable_sort(
     best::callable<best::partial_ord(const T&, const T&)> auto&& get_key) const
   requires(!is_const)
 {

--- a/best/container/span_test.cc
+++ b/best/container/span_test.cc
@@ -287,6 +287,23 @@ best::test Sort = [](auto& t) {
   t.expect_eq(ints, best::span{5, 4, 3, 2, 1});
 };
 
+best::test Bisect = [](auto& t) {
+  int ints[] = {1, 2, 3, 4, 100, 200};
+  t.expect_eq(best::span(ints).bisect(3), best::ok(2));
+  t.expect_eq(best::span(ints).bisect(100), best::ok(4));
+  t.expect_eq(best::span(ints).bisect(55), best::err(4));
+  t.expect_eq(best::span(ints).bisect(0), best::err(0));
+  t.expect_eq(best::span(ints).bisect(1000), best::err(6));
+
+  struct entry {
+    best::str k;
+    size_t v;
+  };
+  entry strs[] = {{"x", 1}, {"y", 2}, {"z", 3}, {"s1", 4}, {"s2", 5}};
+  best::span(strs).sort(&entry::k);
+  t.expect_eq(strs[*best::span(strs).bisect("x", &entry::k)].v, 1);
+};
+
 struct NonPod {
   int x;
   NonPod(int x) : x(x) {}

--- a/best/func/BUILD
+++ b/best/func/BUILD
@@ -12,3 +12,21 @@ cc_library(
     "//best/meta:init",
   ],
 )
+
+cc_library(
+  name = "tap",
+  hdrs = ["tap.h"],
+  deps = [
+    ":call",
+  ],
+)
+
+cc_test(
+  name = "tap_test",
+  srcs = ["tap_test.cc"],
+  linkopts = ["-rdynamic"],
+  deps = [
+    ":tap",
+    "//best/test",
+  ],
+)

--- a/best/func/internal/call.h
+++ b/best/func/internal/call.h
@@ -68,8 +68,8 @@ BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(tag<>, auto&& func,
   return BEST_FWD(func)(BEST_FWD(args)...);
 }
 template <typename... Args>
-BEST_INLINE_SYNTHETIC constexpr auto call(tag<Args...>, auto&& func,
-                                          auto&&... args)
+BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(tag<Args...>, auto&& func,
+                                                    auto&&... args)
   requires requires { func.template operator()<Args...>(BEST_FWD(args)...); } &&
            (sizeof...(Args) > 0)
 {

--- a/best/func/tap.h
+++ b/best/func/tap.h
@@ -1,0 +1,215 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_FUNC_TAP_H_
+#define BEST_FUNC_TAP_H_
+
+#include "best/func/call.h"
+#include "best/meta/tags.h"
+#include "best/meta/taxonomy.h"
+
+//! Taps, `best`'s "functional pipeline" syntax.
+//!
+//! A tap is a type that wraps a function to make it callable as a postfix
+//! operation with `->*`.
+//!
+//! ```
+//! best::tap foo = [](int x) { return x + x; };
+//! int z = 5->*foo;
+//! ```
+//!
+//! Common taps are good for returning out of functions or making into
+//! constants, so you might write
+//!
+//! ```
+//! inline constexpr best::tap MyTap = [](auto x) { ... };
+//!
+//! something->*MyTap->*MyOtherTap(xyz);
+//! ```
+//!
+//! ## Language Bugs
+//!
+//! Because `->*` has lower precedence than `.` and `->`, there are some
+//! limitations. In particular, you can't do `foo->*bar().baz()`, where `bar()`
+//! is a function that returns a tap. You must either parenthesize the tap
+//! expression, `(foo->*bar()).baz()`; or save it to a temporary. you may,
+//! however, chain tap expressions as you might expect.
+//!
+//! `->*` also binds stronger than `operator()` and `operator[]`. However, the
+//! vanilla tap, `best::tap`, overloads `operator()` and `operator[]` to give
+//! the illusion otherwise: `foo->*my_tap(bar)` will be parsed as
+//! `operator->*(foo, my_tap.operator()(bar))`: using `()` or `[]` on a tap will
+//! "bind" those arguments, returning a new tap that "does what you expect",
+//! such that `foo->*my_tap(bar)` is almost `(foo->*my_tap)(bar)`.
+//!
+//! Another quirk is that the following code will not compile:
+//!
+//! ```
+//! MyType{}->*best::tap([](auto&) { ... });
+//! ```
+//!
+//! This is because this gets rewritten as an ordinary function call, so unlike
+//! a call through `.` or `->`, it will not convert the LHS into a non-const
+//! lvalue. In general, you want your taps to take `auto&&`.
+
+namespace best {
+/// # `best::tap`
+///
+/// The basic tap: takes a function and `->*` calls it on the tapped value.
+///
+/// ```
+/// best::tap foo = [](int x) { return x + x; };
+/// int z = 5->*foo;
+/// ```
+template <typename Guard, typename Cb>
+class [[nodiscard(
+    "a best::tap must be called using ->* to have any effect")]] tap final {
+ public:
+  BEST_CTAD_GUARD_("best::tap", Guard);
+
+  /// # `tap::tap()`
+  ///
+  /// Constructs a new tap by wrapping a callback.
+  constexpr tap(Cb&& cb) : cb_(BEST_FWD(cb)) {}
+  constexpr tap(best::bind_t, Cb&& cb) : cb_(BEST_FWD(cb)) {}
+
+  /// # `tap::callback()`
+  ///
+  /// Gets a reference to the wrapped callback.
+  constexpr const Cb& callback() const& { return cb_; }
+  constexpr Cb& callback() & { return cb_; }
+  constexpr const Cb&& callback() const&& { return BEST_MOVE(cb_); }
+  constexpr Cb&& callback() && { return BEST_MOVE(cb_); }
+
+  /// # `tap()`, `tap[]`
+  ///
+  /// Binds arguments for this tap. This makes it possible to use this tap as
+  /// a function call: `foo->*my_tap(bar)`, assuming the tap returns a callable.
+  /// (Respectively for `foo->*my_tap[bar]`).
+  ///
+  /// This works around a quirk of C++'s operator precedence order.
+  constexpr auto operator()(auto&&...) const&;
+  constexpr auto operator()(auto&&...) &;
+  constexpr auto operator()(auto&&...) const&&;
+  constexpr auto operator()(auto&&...) &&;
+  constexpr auto operator[](auto&&) const&;
+  constexpr auto operator[](auto&&) &;
+  constexpr auto operator[](auto&&) const&&;
+  constexpr auto operator[](auto&&) &&;
+
+  /// # `arg->*tap`
+  ///
+  /// "Taps" a value with this tap. This calls the LHS of `->*` with the stored
+  /// callback.
+  constexpr friend decltype(auto) operator->*(auto&& arg, const tap& tap) {
+    return best::call(tap.callback(), BEST_FWD(arg));
+  }
+  constexpr friend decltype(auto) operator->*(auto&& arg, tap& tap) {
+    return best::call(tap.callback(), BEST_FWD(arg));
+  }
+  constexpr friend decltype(auto) operator->*(auto&& arg, const tap&& tap) {
+    return best::call(tap.callback(), BEST_FWD(arg));
+  }
+  constexpr friend decltype(auto) operator->*(auto&& arg, tap&& tap) {
+    return best::call(tap.callback(), BEST_FWD(arg));
+  }
+
+ private:
+  Cb cb_;
+};
+
+/// # `best::inspect()`
+///
+/// Creates an "inspecting tap", i.e., a tap that discards the return value of
+/// the passed closure and returns its argument.
+///
+/// ```
+/// foo(my_vec->*best::inspect([](auto& v) { v.push(42); }));
+/// ```
+constexpr auto inspect(auto&&);
+constexpr auto inspect(best::bind_t, auto&&);
+
+/* ////////////////////////////////////////////////////////////////////////// *\
+ * ////////////////// !!! IMPLEMENTATION DETAILS BELOW !!! ////////////////// *
+\* ////////////////////////////////////////////////////////////////////////// */
+
+template <typename Guard, typename Cb>
+constexpr auto tap<Guard, Cb>::operator()(auto&&... args) const& {
+  return best::tap([&](auto&& arg) -> decltype(auto) {
+    return best::call((BEST_FWD(arg))->**this, BEST_FWD(args)...);
+  });
+}
+template <typename Guard, typename Cb>
+constexpr auto tap<Guard, Cb>::operator()(auto&&... args) & {
+  return best::tap([&](auto&& arg) -> decltype(auto) {
+    return best::call((BEST_FWD(arg))->**this, BEST_FWD(args)...);
+  });
+}
+template <typename Guard, typename Cb>
+constexpr auto tap<Guard, Cb>::operator()(auto&&... args) const&& {
+  return best::tap([&](auto&& arg) -> decltype(auto) {
+    return best::call((BEST_FWD(arg))->*BEST_MOVE(*this), BEST_FWD(args)...);
+  });
+}
+template <typename Guard, typename Cb>
+constexpr auto tap<Guard, Cb>::operator()(auto&&... args) && {
+  return best::tap([&](auto&& arg) -> decltype(auto) {
+    return best::call((BEST_FWD(arg))->*BEST_MOVE(*this), BEST_FWD(args)...);
+  });
+}
+template <typename Guard, typename Cb>
+constexpr auto tap<Guard, Cb>::operator[](auto&& arg) const& {
+  return best::tap([&](auto&& arg) -> decltype(auto) {
+    return ((BEST_FWD(arg))->**this)[BEST_FWD(arg)];
+  });
+}
+template <typename Guard, typename Cb>
+constexpr auto tap<Guard, Cb>::operator[](auto&& arg) & {
+  return best::tap([&](auto&& arg) -> decltype(auto) {
+    return ((BEST_FWD(arg))->**this)[BEST_FWD(arg)];
+  });
+}
+template <typename Guard, typename Cb>
+constexpr auto tap<Guard, Cb>::operator[](auto&& arg) const&& {
+  return best::tap([&](auto&& arg) -> decltype(auto) {
+    return ((BEST_FWD(arg))->*BEST_MOVE(*this))[BEST_FWD(arg)];
+  });
+}
+template <typename Guard, typename Cb>
+constexpr auto tap<Guard, Cb>::operator[](auto&& arg) && {
+  return best::tap([&](auto&& arg) -> decltype(auto) {
+    return ((BEST_FWD(arg))->*BEST_MOVE(*this))[BEST_FWD(arg)];
+  });
+}
+
+constexpr auto inspect(auto&& cb) {
+  return best::tap([cb = BEST_FWD(cb)](auto&& arg) -> decltype(auto) {
+    (void)best::call(cb, BEST_FWD(arg));
+    BEST_FWD(arg);
+  });
+}
+constexpr auto inspect(best::bind_t, auto&& cb) {
+  return best::tap([&](auto&& arg) -> decltype(auto) {
+    (void)best::call(BEST_FWD(cb), BEST_FWD(arg));
+    BEST_FWD(arg);
+  });
+}
+}  // namespace best
+
+#endif  // BEST_FUNC_TAP_H_

--- a/best/func/tap.h
+++ b/best/func/tap.h
@@ -124,10 +124,10 @@ class [[nodiscard(
     return best::call(tap.callback(), BEST_FWD(arg));
   }
   constexpr friend decltype(auto) operator->*(auto&& arg, const tap&& tap) {
-    return best::call(tap.callback(), BEST_FWD(arg));
+    return best::call(BEST_MOVE(tap).callback(), BEST_FWD(arg));
   }
   constexpr friend decltype(auto) operator->*(auto&& arg, tap&& tap) {
-    return best::call(tap.callback(), BEST_FWD(arg));
+    return best::call(BEST_MOVE(tap).callback(), BEST_FWD(arg));
   }
 
  private:

--- a/best/func/tap.h
+++ b/best/func/tap.h
@@ -144,11 +144,13 @@ class [[nodiscard(
 /// ```
 constexpr auto inspect(auto&&);
 constexpr auto inspect(best::bind_t, auto&&);
+}  // namespace best
 
 /* ////////////////////////////////////////////////////////////////////////// *\
  * ////////////////// !!! IMPLEMENTATION DETAILS BELOW !!! ////////////////// *
 \* ////////////////////////////////////////////////////////////////////////// */
 
+namespace best {
 template <typename Guard, typename Cb>
 constexpr auto tap<Guard, Cb>::operator()(auto&&... args) const& {
   return best::tap([&](auto&& arg) -> decltype(auto) {

--- a/best/func/tap_test.cc
+++ b/best/func/tap_test.cc
@@ -1,0 +1,36 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#include "best/func/tap.h"
+
+#include "best/test/test.h"
+
+namespace best::tap_test {
+best::test Tap = [](auto& t) {
+  struct X {
+    int x = 0;
+  };
+
+  int value = X{.x = 4}->*best::tap([](auto x) { return x.x * 2; });
+  t.expect_eq(value, 8);
+
+  best::tap x_plus = [](auto&& x) { return [&](auto y) { return x.x + y; }; };
+  t.expect_eq(X{.x = 4}->*x_plus(5), 9);
+};
+}

--- a/best/meta/BUILD
+++ b/best/meta/BUILD
@@ -82,12 +82,38 @@ cc_library(
 )
 
 cc_library(
+  name = "names",
+  hdrs = [
+    "names.h",
+    "internal/names.h",
+  ],
+  deps = [
+    ":taxonomy",
+    "//best/base:fwd",
+    "//best/text:str",
+  ],
+)
+
+cc_test(
+  name = "names_test",
+  srcs = ["names_test.cc"],
+  linkopts = ["-rdynamic"],
+  deps = [
+    ":names",
+    "//best/test",
+  ]
+)
+
+
+cc_library(
   name = "reflect",
   hdrs = [
     "reflect.h",
     "internal/reflect.h",
+    "internal/reflect_bind.inc",
   ],
   deps = [
+    ":names",
     ":taxonomy",
     "//best/base:fwd",
     "//best/container:row",

--- a/best/meta/BUILD
+++ b/best/meta/BUILD
@@ -117,6 +117,7 @@ cc_library(
     ":taxonomy",
     "//best/base:fwd",
     "//best/container:row",
+    "//best/func:tap",
     "//best/text:str",
   ],
 )
@@ -128,6 +129,7 @@ cc_test(
   deps = [
     ":reflect",
     "//best/test",
+    "//best/test:fodder",
   ]
 )
 

--- a/best/meta/BUILD
+++ b/best/meta/BUILD
@@ -82,6 +82,30 @@ cc_library(
 )
 
 cc_library(
+  name = "reflect",
+  hdrs = [
+    "reflect.h",
+    "internal/reflect.h",
+  ],
+  deps = [
+    ":taxonomy",
+    "//best/base:fwd",
+    "//best/container:row",
+    "//best/text:str",
+  ],
+)
+
+cc_test(
+  name = "reflect_test",
+  srcs = ["reflect_test.cc"],
+  linkopts = ["-rdynamic"],
+  deps = [
+    ":reflect",
+    "//best/test",
+  ]
+)
+
+cc_library(
   name = "tlist",
   hdrs = [
     "tlist.h",

--- a/best/meta/internal/names.h
+++ b/best/meta/internal/names.h
@@ -1,0 +1,138 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_META_INTERNAL_NAMES_H_
+#define BEST_META_INTERNAL_NAMES_H_
+
+#include <source_location>
+
+#include "best/base/fwd.h"
+#include "best/container/span.h"
+#include "best/text/str.h"
+
+// This needs to go in the global namespace, since its full name is relevant for
+// substring operations that extract the names of things. These names are
+// #defined away at the bottom of this header.
+struct BEST_REFLECT_STRUCT_ {
+  BEST_REFLECT_STRUCT_* BEST_REFLECT_FIELD1_;
+  BEST_REFLECT_STRUCT_* BEST_REFLECT_FIELD2_;
+  enum BEST_REFLECT_ENUM_ { BEST_REFLECT_VALUE_ };
+};
+
+namespace best::names_internal {
+// We work exclusively with spans here to avoid pulling in the full machinery
+// of best::str encoding, which is not fast in constexpr.
+template <auto x>
+constexpr best::span<const char> raw_name() {
+  return best::span<const char>::from_nul(
+      std::source_location::current().function_name());
+}
+template <typename x>
+constexpr best::span<const char> raw_name() {
+  return best::span<const char>::from_nul(
+      std::source_location::current().function_name());
+}
+
+// Helpers for creating a structural value that will contain the name of a
+// field symbol.
+template <typename T>
+const T v{};
+template <typename T>
+struct w {
+  const T* p;
+};
+template <typename T>
+w(const T*) -> w<T>;
+
+// Needles to search for that are *definitely* gonna be in the target compiler's
+// pretty printed function names.
+inline constexpr auto TypeNeedle =
+    best::span<const char>::from_nul("BEST_REFLECT_STRUCT_");
+inline constexpr auto FieldNeedle = best::span<const char>::from_nul(
+    "&BEST_REFLECT_STRUCT_::BEST_REFLECT_FIELD1_");
+inline constexpr auto FieldNeedle1 =
+    best::span<const char>::from_nul("BEST_REFLECT_FIELD1_");
+inline constexpr auto FieldNeedle2 =
+    best::span<const char>::from_nul("BEST_REFLECT_FIELD2_");
+inline constexpr auto ValueNeedle = best::span<const char>::from_nul(
+    "BEST_REFLECT_STRUCT_::BEST_REFLECT_VALUE_");
+
+struct raw_offsets {
+  size_t prefix, suffix;
+  best::str separator;
+};
+
+// Figure out how the compiler lays out the names of types, fields, and enum
+// values in the names of function templates.
+inline constexpr auto TypeOffsets = [] {
+  auto name = raw_name<BEST_REFLECT_STRUCT_>();
+  auto idx = *name.find(TypeNeedle);
+  return raw_offsets{
+      .prefix = idx,
+      .suffix = name.size() - idx - TypeNeedle.size(),
+  };
+}();
+inline constexpr auto FieldOffsets = [] {
+  auto name = raw_name<&BEST_REFLECT_STRUCT_::BEST_REFLECT_FIELD1_>();
+  auto idx = *name.find(FieldNeedle1);
+  return raw_offsets{
+      .prefix = idx,
+      .suffix = name.size() - idx - FieldNeedle1.size(),
+  };
+}();
+inline constexpr auto ValueOffsets = [] {
+  auto name =
+      raw_name<BEST_REFLECT_STRUCT_::BEST_REFLECT_ENUM_::BEST_REFLECT_VALUE_>();
+  auto idx = *name.find(ValueNeedle);
+  return raw_offsets{
+      .prefix = idx,
+      .suffix = name.size() - idx - ValueNeedle.size(),
+  };
+}();
+
+inline constexpr auto BulkFieldOffsets = [] {
+  auto name = names_internal::raw_name<std::array{
+      (const void*)&v<BEST_REFLECT_STRUCT_>.BEST_REFLECT_FIELD1_,
+      (const void*)&v<BEST_REFLECT_STRUCT_>.BEST_REFLECT_FIELD2_}>();
+  auto idx = *name.find(FieldNeedle1);
+  auto idx2 = *name.find(FieldNeedle2);
+  return raw_offsets{
+      .prefix = idx,
+      .suffix = name.size() - idx2 - FieldNeedle2.size(),
+      .separator =
+          str(unsafe{"the compiler made this string, it better be UTF-8"},
+              name[{.start = idx + FieldNeedle1.size(), .end = idx2}]),
+  };
+}();
+
+constexpr best::str remove_namespace(best::str path) {
+  while (auto split = path.split_on("::")) {
+    path = split->second();
+  }
+  return path;
+}
+};  // namespace best::names_internal
+
+#define BEST_REFLECT_FIELD1_ _private
+#define BEST_REFLECT_FIELD2_ _private
+#define BEST_REFLECT_STRUCT_ _private
+#define BEST_REFLECT_VALUE_ _private
+#define BEST_REFLECT_ENUM_ _private
+
+#endif  // BEST_META_INTERNAL_REFLECT_H_

--- a/best/meta/internal/names.h
+++ b/best/meta/internal/names.h
@@ -195,6 +195,8 @@ constexpr best::str parse() {
                    prefix[{.start = i}]);
 }
 
+BEST_PUSH_GCC_DIAGNOSTIC()
+BEST_IGNORE_GCC_DIAGNOSTIC("-Wenum-constexpr-conversion")
 template <best::is_enum auto e>
 constexpr best::option<best::str> parse() {
   auto offsets = names_internal::ValueOffsets;
@@ -210,6 +212,7 @@ constexpr best::option<best::str> parse() {
   // `name` is going to be scoped, so we need to strip off a leading path.
   return names_internal::remove_namespace(name);
 };
+BEST_POP_GCC_DIAGNOSTIC()
 
 };  // namespace best::names_internal
 

--- a/best/meta/internal/reflect.h
+++ b/best/meta/internal/reflect.h
@@ -1,86 +1,47 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
 #ifndef BEST_META_INTERNAL_REFLECT_H_
 #define BEST_META_INTERNAL_REFLECT_H_
 
-#include <source_location>
-
 #include "best/base/fwd.h"
+#include "best/meta/internal/names.h"
 #include "best/meta/taxonomy.h"
 #include "best/text/str.h"
 
-// This needs to go in the global namespace, since its full name is relevant for
-// substring operations that extract the names of things. These names are
-// #defined away at the bottom of this header.
-struct BEST_REFLECT_STRUCT_ {
-  BEST_REFLECT_STRUCT_* BEST_REFLECT_FIELD_;
-  enum BEST_REFLECT_ENUM_ { BEST_REFLECT_VALUE_ };
-};
-
 namespace best::reflect_internal {
-// We work exclusively with spans here to avoid pulling in the full machinery
-// of best::str encoding, which is not fast in constexpr.
-template <auto x>
-constexpr best::span<const char> raw_name() {
-  return best::span<const char>::from_nul(
-      std::source_location::current().function_name());
+/// A value that can convert to any other, used in the structured bindings
+/// visitors.
+inline constexpr struct any_t {
+  template <typename T>
+  operator T() const;
+} any;
+
+/// # `best::reflect_internal::bind(cb, struct)`
+///
+/// The struct manipulation primitive: this explodes a struct into a tuple using
+/// the power of structured bindings.
+#include "best/meta/internal/reflect_bind.inc"
+constexpr decltype(auto) bind(auto&& val, auto&& cb) {
+  return reflect_internal::bind(BEST_FWD(val), BEST_FWD(cb),
+                                best::rank<BEST_REFLECT_MAX_FIELDS_>{});
 }
-template <typename x>
-constexpr best::span<const char> raw_name() {
-  return best::span<const char>::from_nul(
-      std::source_location::current().function_name());
-}
-
-// Needles to search for that are *definitely* gonna be in the target compiler's
-// pretty printed function names.
-inline constexpr auto TypeNeedle =
-    best::span<const char>::from_nul("BEST_REFLECT_STRUCT_");
-inline constexpr auto FieldNeedle =
-    best::span<const char>::from_nul("BEST_REFLECT_FIELD_");
-inline constexpr auto ValueNeedle = best::span<const char>::from_nul(
-    "BEST_REFLECT_STRUCT_::BEST_REFLECT_ENUM_::BEST_REFLECT_VALUE_");
-
-struct raw_offsets {
-  size_t start_offset;
-  size_t suffix_len;
-};
-
-// Helpers for creating a structural value that will contain the name of a
-// field symbol.
-template <typename T>
-extern const T v;
-template <typename T>
-struct w {
-  const T* p;
-};
-template <typename T>
-w(const T*) -> w<T>;
-
-// Figure out how the compiler lays out the names of types, fields, and enum
-// values in the names of function templates.
-// inline constexpr auto TypeOffsets = [] {
-//   auto name = raw_name<BEST_REFLECT_STRUCT_>();
-//   auto idx = *name.find(TypeNeedle);
-//   return raw_offsets{
-//       .start_offset = idx,
-//       .suffix_len = name.size() - idx - TypeNeedle.size(),
-//   };
-// }();
-// inline constexpr auto FieldOffsets = [] {
-//   auto name = raw_name<w{&v<BEST_REFLECT_STRUCT_>.BEST_REFLECT_FIELD_}>();
-//   auto idx = *name.find(FieldNeedle);
-//   return raw_offsets{
-//       .start_offset = idx,
-//       .suffix_len = name.size() - idx - FieldNeedle.size(),
-//   };
-// }();
-// inline constexpr auto ValueOffsets = [] {
-//   auto name =
-//       raw_name<BEST_REFLECT_STRUCT_::BEST_REFLECT_ENUM_::BEST_REFLECT_VALUE_>();
-//   auto idx = *name.find(ValueNeedle);
-//   return raw_offsets{
-//       .start_offset = idx,
-//       .suffix_len = name.size() - idx - ValueNeedle.size(),
-//   };
-// }();
 
 enum kind { Field, Struct, Value, Enum, NoFields };
 
@@ -96,46 +57,122 @@ struct validator {
 template <typename Info, typename For>
 concept valid_reflection = validator::value<Info, For>;
 
-template <typename S, typename T, typename... Tags>
+template <typename Info>
+concept is_info = requires {
+  { Info::Kind } -> best::same<kind>;
+};
+
+template <typename T, best::is_row Tags>
 class field_info final {
   template <auto&>
   friend class best::reflected_field;
   template <auto&>
   friend class best::reflected_type;
-  friend mirror;
+  template <typename>
+  friend class mirror;
   friend validator;
 
-  using struct_ = S;
   using type = T;
   inline static constexpr auto Kind = Field;
 
-  constexpr field_info(best::str name, type struct_::*ptr,
-                       best::row<Tags...> tags)
-      : name_(name), ptr_(ptr), tags_(tags) {}
+ public:
+  constexpr field_info(best::str name, Tags tags) : name_(name), tags_(tags) {}
 
+ private:
   best::str name_;
-  type struct_::*ptr_;
-  best::row<Tags...> tags_;
+  Tags tags_;
 };
 
-template <typename S, typename Tags, typename... Fields>
+/// Can't use best::equals, because that doesn't discriminate by type when
+/// comparing pointers. This version does: pointers of distinct types compare
+/// as unequal. This is necessary to deal with [[no_unique_address]] fields
+/// correctly.
+template <typename T>
+constexpr bool equals(const T* a, const T* b) {
+  return a == b;
+}
+constexpr bool equals(const auto* a, const auto* b) { return false; }
+
+template <typename S, best::is_row Fields, best::is_row Tags>
 class struct_info final {
   template <auto&>
   friend class best::reflected_type;
-  friend mirror;
+  template <typename>
+  friend class mirror;
   friend validator;
 
   using struct_ = S;
   using enum_ = void;
   inline static constexpr auto Kind = Struct;
 
-  constexpr struct_info(best::str name, Tags tags, best::row<Fields...> fields)
-      : name_(name), tags_(tags), items_(fields) {}
+ public:
+  constexpr struct_info(Fields fields, Tags tags)
+      : items_(fields), tags_(tags) {}
 
-  best::str name_;
+ //private:
+  // Finds the index of a field, given a pointer-to-member.
+  template <auto pm>
+  constexpr auto index() const {
+    // First, find the index of this member. The simplest way is to compare
+    // pointers.
+    size_t idx = 0;
+    auto* ptr = best::addr(names_internal::v<S>.*pm);
+    bind(names_internal::v<S>, [&](auto&&... fields) {
+      // NB: If this is ever a problem for optimization, note that it can likely
+      // be realized as binary search.
+      ((reflect_internal::equals(best::addr(fields), ptr) ? true
+                                                          : (idx++, false)) ||
+       ...);
+    });
+    return idx;
+  }
+
+  // Adds tags to a field.
+  template <auto pm>
+  auto add(auto... tags) {
+    
+  }
+
+  Fields items_;
   Tags tags_;
-  best::row<Fields...> items_;
 };
+
+template <best::is_struct S>
+constexpr auto infer_struct() {
+  constexpr size_t num_fields = bind(
+      names_internal::v<S>, [](auto&&... fields) { return sizeof...(fields); });
+  constexpr auto raw_names =
+      names_internal::raw_name<bind(names_internal::v<S>, [](auto&&... fields) {
+        return std::array{(const void*)best::addr(fields)...};
+      })>();
+  constexpr auto names = [&] {
+    auto offsets = names_internal::BulkFieldOffsets;
+    auto to_parse =
+        str(unsafe{"the compiler made this string, it better be UTF-8"},
+            raw_names[{
+                .start = offsets.prefix,
+                .end = raw_names.size() - offsets.suffix,
+            }]);
+
+    size_t idx = 0;
+    std::array<best::str, num_fields> names{};
+    while (auto split = to_parse.split_on(offsets.separator)) {
+      names[idx++] = split->first();
+      to_parse = split->second();
+    }
+    names[idx] = to_parse;
+
+    return names;
+  }();
+
+  auto fields = bind(names_internal::v<S>, [&](auto&&... fields) {
+    size_t idx = 0;
+    return best::row{field_info<best::unref<decltype(fields)>, best::row<>>(
+        names[idx++], {})...};
+  });
+
+  return struct_info<S, decltype(fields), best::row<>>(fields, {});
+}
 
 template <typename E, typename... Tags>
 class elem_info final {
@@ -143,7 +180,8 @@ class elem_info final {
   friend class best::reflected_value;
   template <auto&>
   friend class best::reflected_type;
-  friend mirror;
+  template <typename>
+  friend class mirror;
   friend validator;
 
   using enum_ = E;
@@ -161,7 +199,8 @@ template <typename E, typename Tags, typename... Elems>
 class enum_info final {
   template <auto&>
   friend class best::reflected_type;
-  friend mirror;
+  template <typename>
+  friend class mirror;
   friend validator;
 
   using struct_ = void;
@@ -180,7 +219,8 @@ template <typename Tags>
 class no_fields final {
   template <auto&>
   friend class best::reflected_type;
-  friend mirror;
+  template <typename>
+  friend class mirror;
   friend validator;
 
   using struct_ = void;
@@ -194,7 +234,7 @@ class no_fields final {
   best::row<> items_;
 };
 
-template <typename T, typename mirror = best::mirror>
+template <typename T, typename mirror = best::mirror<T>>
 inline constexpr auto info = BestReflect(mirror::BEST_MIRROR_FTADLE_, (T*){});
 
 };  // namespace best::reflect_internal

--- a/best/meta/internal/reflect.h
+++ b/best/meta/internal/reflect.h
@@ -22,18 +22,118 @@
 
 #include "best/base/fwd.h"
 #include "best/meta/internal/names.h"
+#include "best/meta/names.h"
 #include "best/meta/taxonomy.h"
 #include "best/text/str.h"
 
+//! Reflection descriptors.
+//!
+//! This header defines the internal reflection descriptors that carry the
+//! necessary information for constructing reflections of structs and enums.
+
 namespace best::reflect_internal {
+using ::best::names_internal::eyepatch;
+using ::best::names_internal::materialize;
+
+// BestRowKeys for fdesc/vdesc.
+template <auto>
+struct fkey {};
+template <auto>
+struct vkey {};
+
+// Fwd decls of the descriptor classes. The classes are completely private so
+// users cannot tamper with them, but they befriend all of the reflection types.
+// They have a lot of friends, so we define a macro to help keep them tidy.
+template <typename, best::is_row = best::row<>, best::is_row = best::row<>>
+class tdesc;  // Type descriptor.
+template <auto, typename, typename, best::is_row = best::row<>>
+class fdesc;  // Field descriptor.
+template <auto, best::is_row = best::row<>>
+class vdesc;  // Enum value descriptor.
+
+// CTAD deduction guides for the descriptors.
+template <typename S, best::is_row Items, best::is_row Tags>
+tdesc(best::tlist<S>, Items, Tags) -> tdesc<S, Items, Tags>;
+template <auto p, typename S, typename Get, best::is_row Tags>
+fdesc(best::vlist<p>, best::tlist<S>, Get, Tags) -> fdesc<p, S, Get, Tags>;
+template <auto e, best::is_row Tags>
+vdesc(best::vlist<e>, Tags) -> vdesc<e, Tags>;
+
+// Used in the reflection classes to validate that they are specialized
+// correctly. They contain static asserts that check for the right kind value.
+enum kind { Field, Value, Type };
+
+// Concepts can't be befriended, so we indirect through this type.
+template <typename Info, typename For>
+struct validator {
+  static constexpr bool value =
+      Info::Kind == Type && best::same<For, typename Info::type>;
+};
+template <typename Info, typename For>
+concept valid_reflection = validator<best::as_auto<Info>, For>::value;
+
+// Friend declarations shared by all descriptors.
+#define BEST_DESCRIPTOR_FRIENDS_                    \
+  template <auto&>                                  \
+  friend class best::reflected_type;                \
+  template <auto&>                                  \
+  friend class best::reflected_field;               \
+  template <auto&>                                  \
+  friend class best::reflected_value;               \
+  template <typename>                               \
+  friend class best::mirror;                        \
+                                                    \
+  template <typename, best::is_row, best::is_row>   \
+  friend class reflect_internal::tdesc;             \
+  template <auto, typename, typename, best::is_row> \
+  friend class reflect_internal::fdesc;             \
+  template <auto, best::is_row>                     \
+  friend class reflect_internal::vdesc;             \
+  template <typename, typename>                     \
+  friend struct reflect_internal::validator;
+
+// Discards anything it is constructed with. This is used for the inlined
+// version of "select element" used in infer_struct().
+struct discard {
+  constexpr discard(auto&&) {}
+};
+
+/// Can't use best::equals, because that doesn't discriminate by type when
+/// comparing pointers. This version does: pointers of distinct types compare
+/// as unequal. This is necessary to deal with [[no_unique_address]] fields
+/// correctly.
+template <typename T, typename U>
+constexpr bool typed_addr_eq(T* a, U* b)
+  requires best::same<best::unqual<T>, best::unqual<U>>
+{
+  return a == b;
+}
+constexpr bool typed_addr_eq(...) { return false; }
+
 /// A value that can convert to any other, used in the structured bindings
 /// visitors.
 inline constexpr struct any_t {
   template <typename T>
   operator T() const;
 } any;
+template <size_t>
+inline constexpr any_t index_any{};
 
-/// # `best::reflect_internal::bind(cb, struct)`
+/// Counts the number of fields in the struct T by recursively trying to
+/// construct a T with `n` arguments; once it hits a failure, we know we found
+/// the largest number of arguments it can be initialized with.
+template <best::is_struct T, size_t... i>
+constexpr size_t count_fields() {
+  if constexpr (!requires { T{index_any<i>...}; }) {
+    return sizeof...(i) - 1;
+  } else {
+    return count_fields<T, i..., sizeof...(i)>();
+  }
+}
+template <best::is_struct T>
+inline constexpr size_t total_fields = count_fields<T, 0>();
+
+/// # `best::reflect_internal::bind(struct, cb)`
 ///
 /// The struct manipulation primitive: this explodes a struct into a tuple using
 /// the power of structured bindings.
@@ -43,205 +143,209 @@ constexpr decltype(auto) bind(auto&& val, auto&& cb) {
                                 best::rank<BEST_REFLECT_MAX_FIELDS_>{});
 }
 
-enum kind { Field, Struct, Value, Enum, NoFields };
+/// # `best::reflect_internal::bind(struct)`
+///
+/// Binds the `n`th field of `struct`.
+template <size_t n>
+constexpr decltype(auto) bind(auto&& val) {
+  return best::indices<n>.apply([&]<typename... I>() -> decltype(auto) {
+    return reflect_internal::bind(
+        BEST_FWD(val),
+        [&](best::dependent<discard, I>..., auto&& the_one,
+            auto&&... rest) -> decltype(auto) {
+          // Structured bindings' type does not preserve value category
+          // correctly, so we need to adjust its type to match the value
+          // category of `val`.
+          return best::refcopy<decltype(the_one), decltype(val)>(the_one);
+        });
+  });
+}
 
-struct validator {
-  /// This needs to be in a struct so the info classes can befriend it.
-  template <typename Info, typename For>
-  static constexpr bool value =
-      (Info::Kind == Struct && best::same<For, typename Info::struct_>) ||
-      (Info::Kind == Enum && best::same<For, typename Info::enum_>) ||
-      (Info::Kind == NoFields && (best::is_struct<For> || best::is_enum<For>));
-};
-
-template <typename Info, typename For>
-concept valid_reflection = validator::value<Info, For>;
-
-template <typename Info>
-concept is_info = requires {
-  { Info::Kind } -> best::same<kind>;
-};
-
-template <typename T, best::is_row Tags>
-class field_info final {
-  template <auto&>
-  friend class best::reflected_field;
-  template <auto&>
-  friend class best::reflected_type;
-  template <typename>
-  friend class mirror;
-  friend validator;
-
-  using type = T;
-  inline static constexpr auto Kind = Field;
-
+template <auto p, typename S, typename Get, best::is_row Tags>
+class fdesc final {
  public:
-  constexpr field_info(best::str name, Tags tags) : name_(name), tags_(tags) {}
+  using BestRowKey = fkey<p>;
 
  private:
-  best::str name_;
-  Tags tags_;
-};
-
-/// Can't use best::equals, because that doesn't discriminate by type when
-/// comparing pointers. This version does: pointers of distinct types compare
-/// as unequal. This is necessary to deal with [[no_unique_address]] fields
-/// correctly.
-template <typename T>
-constexpr bool equals(const T* a, const T* b) {
-  return a == b;
-}
-constexpr bool equals(const auto* a, const auto* b) { return false; }
-
-template <typename S, best::is_row Fields, best::is_row Tags>
-class struct_info final {
-  template <auto&>
-  friend class best::reflected_type;
-  template <typename>
-  friend class mirror;
-  friend validator;
+  BEST_DESCRIPTOR_FRIENDS_
 
   using struct_ = S;
-  using enum_ = void;
-  inline static constexpr auto Kind = Struct;
+  using type = best::unptr<decltype(p.unwrap)>;
+  inline static constexpr auto Kind = Field;
 
- public:
-  constexpr struct_info(Fields fields, Tags tags)
-      : items_(fields), tags_(tags) {}
+  constexpr fdesc(best::vlist<p>, best::tlist<S>, Get get, Tags tags)
+      : get_(get), tags_(tags) {}
 
- //private:
-  // Finds the index of a field, given a pointer-to-member.
-  template <auto pm>
-  constexpr auto index() const {
-    // First, find the index of this member. The simplest way is to compare
-    // pointers.
-    size_t idx = 0;
-    auto* ptr = best::addr(names_internal::v<S>.*pm);
-    bind(names_internal::v<S>, [&](auto&&... fields) {
-      // NB: If this is ever a problem for optimization, note that it can likely
-      // be realized as binary search.
-      ((reflect_internal::equals(best::addr(fields), ptr) ? true
-                                                          : (idx++, false)) ||
-       ...);
-    });
-    return idx;
+  // Adds tags to this field.
+  constexpr auto add(auto... tags) const {
+    return reflect_internal::fdesc(best::vals<p>, best::types<S>, get_,
+                                   tags_ + best::row(tags...));
   }
 
-  // Adds tags to a field.
-  template <auto pm>
-  auto add(auto... tags) {
-    
-  }
+  // A (wrapped) pointer into materialized<T>.
+  static constexpr auto materialized = p;
 
-  Fields items_;
+  static constexpr best::str name_ = names_internal::parse<p>();
+  Get get_;
   Tags tags_;
 };
 
-template <best::is_struct S>
-constexpr auto infer_struct() {
-  constexpr size_t num_fields = bind(
-      names_internal::v<S>, [](auto&&... fields) { return sizeof...(fields); });
-  constexpr auto raw_names =
-      names_internal::raw_name<bind(names_internal::v<S>, [](auto&&... fields) {
-        return std::array{(const void*)best::addr(fields)...};
-      })>();
-  constexpr auto names = [&] {
-    auto offsets = names_internal::BulkFieldOffsets;
-    auto to_parse =
-        str(unsafe{"the compiler made this string, it better be UTF-8"},
-            raw_names[{
-                .start = offsets.prefix,
-                .end = raw_names.size() - offsets.suffix,
-            }]);
+template <auto e, best::is_row Tags>
+class vdesc final {
+ public:
+  using BestRowKey = vkey<e>;
 
-    size_t idx = 0;
-    std::array<best::str, num_fields> names{};
-    while (auto split = to_parse.split_on(offsets.separator)) {
-      names[idx++] = split->first();
-      to_parse = split->second();
-    }
-    names[idx] = to_parse;
+ private:
+  BEST_DESCRIPTOR_FRIENDS_
 
-    return names;
-  }();
-
-  auto fields = bind(names_internal::v<S>, [&](auto&&... fields) {
-    size_t idx = 0;
-    return best::row{field_info<best::unref<decltype(fields)>, best::row<>>(
-        names[idx++], {})...};
-  });
-
-  return struct_info<S, decltype(fields), best::row<>>(fields, {});
-}
-
-template <typename E, typename... Tags>
-class elem_info final {
-  template <auto&>
-  friend class best::reflected_value;
-  template <auto&>
-  friend class best::reflected_type;
-  template <typename>
-  friend class mirror;
-  friend validator;
-
-  using enum_ = E;
+  using enum_ = decltype(e);
   inline static constexpr auto Kind = Value;
 
-  constexpr elem_info(best::str name, enum_ elem, best::row<Tags...> tags)
-      : name_(name), elem_(elem), tags_(tags) {}
+  constexpr vdesc(best::vlist<e>, Tags tags) : tags_(tags) {}
 
-  best::str name_;
-  enum_ elem_;
-  best::row<Tags...> tags_;
+  // Adds tags to this value.
+  constexpr auto add(auto... tags) const {
+    return reflect_internal::vdesc(best::vals<e>, tags_ + best::row(tags...));
+  }
+
+  inline static constexpr enum_ elem_ = e;
+  Tags tags_;
 };
 
-template <typename E, typename Tags, typename... Elems>
-class enum_info final {
-  template <auto&>
-  friend class best::reflected_type;
-  template <typename>
-  friend class mirror;
-  friend validator;
+template <typename T, best::is_row Items, best::is_row Tags>
+class tdesc final {
+ private:
+  BEST_DESCRIPTOR_FRIENDS_
 
-  using struct_ = void;
-  using enum_ = E;
-  inline static constexpr auto Kind = Enum;
+  using type = T;
+  inline static constexpr auto Kind = Type;
 
-  constexpr enum_info(best::str name, Tags tags, best::row<Elems...> values)
-      : name_(name), tags_(tags), items_(values) {}
+  constexpr tdesc(best::tlist<T>, Items items, Tags tags)
+      : items_(items), tags_(tags) {}
 
-  best::str name_;
+  // Adds tags to this type.
+  constexpr auto add(auto... tags) const {
+    return reflect_internal::tdesc(best::types<T>, items_,
+                                   tags_ + best::row(tags...));
+  }
+
+  // Finds the index of a field, given a pointer-to-member.
+  template <best::is_member_ptr auto pm>
+  constexpr auto find() const {
+    return items_.select_indices(
+        best::types<fkey<eyepatch(best::addr(materialize<T>().*pm))>>);
+  }
+
+  // Adds a field or updates it by appending tags
+  template <best::is_member_ptr auto pm>
+  constexpr auto add(auto... tags) const {
+    auto found = find<pm>();
+    if constexpr (found.is_empty()) {
+      return reflect_internal::tdesc(
+          best::types<T>,
+          items_.push(fdesc(
+              best::vals<eyepatch(best::addr(materialize<T>().*pm))>,
+              best::types<T>,
+              [](auto&& value) -> decltype(auto) {
+                return BEST_FWD(value).*pm;
+              },
+              best::row(tags...))),
+          tags_);
+    } else {
+      return reflect_internal::tdesc(
+          best::types<T>,
+          items_.update(
+              items_[best::index<found.template value<0>>].add(tags...),
+              best::index<found.template value<0>>),
+          tags_);
+    }
+  }
+
+  // Finds the index of an enum value, given the value.
+  template <best::is_enum auto e>
+  constexpr auto find() const {
+    return items_.select_indices(best::types<vkey<e>>);
+  }
+
+  // Adds a value or updates it by appending tags
+  template <best::is_enum auto e>
+  constexpr auto add(auto... tags) const {
+    auto found = find<e>();
+    if constexpr (found.is_empty()) {
+      return reflect_internal::tdesc(
+          best::types<T>, items_.push(vdesc(best::vals<e>, best::row(tags...))),
+          tags_);
+    } else {
+      return reflect_internal::tdesc(
+          best::types<T>,
+          items_.update(
+              items_[best::index<found.template value<0>>].add(tags...),
+              best::index<found.template value<0>>),
+          tags_);
+    }
+  }
+
+  // Hides an item.
+  template <auto x>
+  constexpr auto hide() const {
+    auto found = find<x>();
+    return reflect_internal::tdesc(
+        best::types<T>, items_.remove(best::index<found.template value<0>>),
+        tags_);
+  }
+
+  // Infers the default reflection descriptor for a struct.
+  static constexpr auto infer_struct()
+    requires best::is_struct<T>
+  {
+    auto fields = best::indices<total_fields<T>>.apply([&]<typename... I>() {
+      return best::row{fdesc(
+          best::vals<eyepatch(
+              best::addr(reflect_internal::bind<I::value>(materialize<T>())))>,
+          best::types<T>,
+          [](auto&& v) -> decltype(auto) {
+            return reflect_internal::bind<I::value>(BEST_FWD(v));
+          },
+          best::row())...};
+    });
+    return reflect_internal::tdesc(best::types<T>, fields, best::row());
+  }
+
+  // Infers the default reflection descriptor for an enum.
+  template <size_t start, size_t count>
+  static constexpr auto infer_enum()
+    requires best::is_enum<T>
+  {
+    constexpr auto ok = best::indices<count>.apply([]<typename... I> {
+      constexpr size_t ok_count =
+          (0 + ... + best::value_name<T(start + I::value)>.has_value());
+
+      std::array<T, ok_count> ok;
+      size_t idx = 0;
+
+      ((best::value_name<T(start + I::value)>.has_value()
+            ? void(ok[idx++] = T(start + I::value))
+            : void()),
+       ...);
+      return ok;
+    });
+    auto values = best::indices<ok.size()>.apply([&]<typename... I> {
+      return best::row{vdesc{
+          best::vals<ok[I::value]>,
+          best::row(),
+      }...};
+    });
+    return reflect_internal::tdesc(best::types<T>, values, best::row());
+  }
+
+  Items items_;
   Tags tags_;
-  best::row<Elems...> items_;
-};
-
-template <typename Tags>
-class no_fields final {
-  template <auto&>
-  friend class best::reflected_type;
-  template <typename>
-  friend class mirror;
-  friend validator;
-
-  using struct_ = void;
-  using enum_ = void;
-  inline static constexpr auto Kind = NoFields;
-
-  constexpr no_fields(best::str name, Tags tags) : name_(name), tags_(tags) {}
-
-  best::str name_;
-  Tags tags_;
-  best::row<> items_;
 };
 
 template <typename T, typename mirror = best::mirror<T>>
-inline constexpr auto info = BestReflect(mirror::BEST_MIRROR_FTADLE_, (T*){});
-
+  requires requires { BestReflect(mirror::BEST_MIRROR_FTADLE_, (T*){}); }
+inline constexpr auto desc = BestReflect(mirror::BEST_MIRROR_FTADLE_, (T*){});
 };  // namespace best::reflect_internal
 
-#define BEST_REFLECT_FIELD_ _private
-#define BEST_REFLECT_STRUCT_ _private
-#define BEST_REFLECT_VALUE_ _private
-#define BEST_REFLECT_ENUM_ _private
-
+#undef BEST_DESCRIPTOR_FRIENDS_
 #endif  // BEST_META_INTERNAL_REFLECT_H_

--- a/best/meta/internal/reflect.h
+++ b/best/meta/internal/reflect.h
@@ -1,0 +1,207 @@
+#ifndef BEST_META_INTERNAL_REFLECT_H_
+#define BEST_META_INTERNAL_REFLECT_H_
+
+#include <source_location>
+
+#include "best/base/fwd.h"
+#include "best/meta/taxonomy.h"
+#include "best/text/str.h"
+
+// This needs to go in the global namespace, since its full name is relevant for
+// substring operations that extract the names of things. These names are
+// #defined away at the bottom of this header.
+struct BEST_REFLECT_STRUCT_ {
+  BEST_REFLECT_STRUCT_* BEST_REFLECT_FIELD_;
+  enum BEST_REFLECT_ENUM_ { BEST_REFLECT_VALUE_ };
+};
+
+namespace best::reflect_internal {
+// We work exclusively with spans here to avoid pulling in the full machinery
+// of best::str encoding, which is not fast in constexpr.
+template <auto x>
+constexpr best::span<const char> raw_name() {
+  return best::span<const char>::from_nul(
+      std::source_location::current().function_name());
+}
+template <typename x>
+constexpr best::span<const char> raw_name() {
+  return best::span<const char>::from_nul(
+      std::source_location::current().function_name());
+}
+
+// Needles to search for that are *definitely* gonna be in the target compiler's
+// pretty printed function names.
+inline constexpr auto TypeNeedle =
+    best::span<const char>::from_nul("BEST_REFLECT_STRUCT_");
+inline constexpr auto FieldNeedle =
+    best::span<const char>::from_nul("BEST_REFLECT_FIELD_");
+inline constexpr auto ValueNeedle = best::span<const char>::from_nul(
+    "BEST_REFLECT_STRUCT_::BEST_REFLECT_ENUM_::BEST_REFLECT_VALUE_");
+
+struct raw_offsets {
+  size_t start_offset;
+  size_t suffix_len;
+};
+
+// Helpers for creating a structural value that will contain the name of a
+// field symbol.
+template <typename T>
+extern const T v;
+template <typename T>
+struct w {
+  const T* p;
+};
+template <typename T>
+w(const T*) -> w<T>;
+
+// Figure out how the compiler lays out the names of types, fields, and enum
+// values in the names of function templates.
+// inline constexpr auto TypeOffsets = [] {
+//   auto name = raw_name<BEST_REFLECT_STRUCT_>();
+//   auto idx = *name.find(TypeNeedle);
+//   return raw_offsets{
+//       .start_offset = idx,
+//       .suffix_len = name.size() - idx - TypeNeedle.size(),
+//   };
+// }();
+// inline constexpr auto FieldOffsets = [] {
+//   auto name = raw_name<w{&v<BEST_REFLECT_STRUCT_>.BEST_REFLECT_FIELD_}>();
+//   auto idx = *name.find(FieldNeedle);
+//   return raw_offsets{
+//       .start_offset = idx,
+//       .suffix_len = name.size() - idx - FieldNeedle.size(),
+//   };
+// }();
+// inline constexpr auto ValueOffsets = [] {
+//   auto name =
+//       raw_name<BEST_REFLECT_STRUCT_::BEST_REFLECT_ENUM_::BEST_REFLECT_VALUE_>();
+//   auto idx = *name.find(ValueNeedle);
+//   return raw_offsets{
+//       .start_offset = idx,
+//       .suffix_len = name.size() - idx - ValueNeedle.size(),
+//   };
+// }();
+
+enum kind { Field, Struct, Value, Enum, NoFields };
+
+struct validator {
+  /// This needs to be in a struct so the info classes can befriend it.
+  template <typename Info, typename For>
+  static constexpr bool value =
+      (Info::Kind == Struct && best::same<For, typename Info::struct_>) ||
+      (Info::Kind == Enum && best::same<For, typename Info::enum_>) ||
+      (Info::Kind == NoFields && (best::is_struct<For> || best::is_enum<For>));
+};
+
+template <typename Info, typename For>
+concept valid_reflection = validator::value<Info, For>;
+
+template <typename S, typename T, typename... Tags>
+class field_info final {
+  template <auto&>
+  friend class best::reflected_field;
+  template <auto&>
+  friend class best::reflected_type;
+  friend mirror;
+  friend validator;
+
+  using struct_ = S;
+  using type = T;
+  inline static constexpr auto Kind = Field;
+
+  constexpr field_info(best::str name, type struct_::*ptr,
+                       best::row<Tags...> tags)
+      : name_(name), ptr_(ptr), tags_(tags) {}
+
+  best::str name_;
+  type struct_::*ptr_;
+  best::row<Tags...> tags_;
+};
+
+template <typename S, typename Tags, typename... Fields>
+class struct_info final {
+  template <auto&>
+  friend class best::reflected_type;
+  friend mirror;
+  friend validator;
+
+  using struct_ = S;
+  using enum_ = void;
+  inline static constexpr auto Kind = Struct;
+
+  constexpr struct_info(best::str name, Tags tags, best::row<Fields...> fields)
+      : name_(name), tags_(tags), items_(fields) {}
+
+  best::str name_;
+  Tags tags_;
+  best::row<Fields...> items_;
+};
+
+template <typename E, typename... Tags>
+class elem_info final {
+  template <auto&>
+  friend class best::reflected_value;
+  template <auto&>
+  friend class best::reflected_type;
+  friend mirror;
+  friend validator;
+
+  using enum_ = E;
+  inline static constexpr auto Kind = Value;
+
+  constexpr elem_info(best::str name, enum_ elem, best::row<Tags...> tags)
+      : name_(name), elem_(elem), tags_(tags) {}
+
+  best::str name_;
+  enum_ elem_;
+  best::row<Tags...> tags_;
+};
+
+template <typename E, typename Tags, typename... Elems>
+class enum_info final {
+  template <auto&>
+  friend class best::reflected_type;
+  friend mirror;
+  friend validator;
+
+  using struct_ = void;
+  using enum_ = E;
+  inline static constexpr auto Kind = Enum;
+
+  constexpr enum_info(best::str name, Tags tags, best::row<Elems...> values)
+      : name_(name), tags_(tags), items_(values) {}
+
+  best::str name_;
+  Tags tags_;
+  best::row<Elems...> items_;
+};
+
+template <typename Tags>
+class no_fields final {
+  template <auto&>
+  friend class best::reflected_type;
+  friend mirror;
+  friend validator;
+
+  using struct_ = void;
+  using enum_ = void;
+  inline static constexpr auto Kind = NoFields;
+
+  constexpr no_fields(best::str name, Tags tags) : name_(name), tags_(tags) {}
+
+  best::str name_;
+  Tags tags_;
+  best::row<> items_;
+};
+
+template <typename T, typename mirror = best::mirror>
+inline constexpr auto info = BestReflect(mirror::BEST_MIRROR_FTADLE_, (T*){});
+
+};  // namespace best::reflect_internal
+
+#define BEST_REFLECT_FIELD_ _private
+#define BEST_REFLECT_STRUCT_ _private
+#define BEST_REFLECT_VALUE_ _private
+#define BEST_REFLECT_ENUM_ _private
+
+#endif  // BEST_META_INTERNAL_REFLECT_H_

--- a/best/meta/internal/reflect_bind.inc
+++ b/best/meta/internal/reflect_bind.inc
@@ -1,0 +1,326 @@
+// GENERATED CODE! DO NOT EDIT! See reflect_bind.sh.
+#define BEST_REFLECT_MAX_FIELDS_ 64
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<0>)
+requires requires { best::as_auto<decltype(val)>{}; } {
+  return best::call(BEST_FWD(cb));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<1>)
+requires requires { best::as_auto<decltype(val)>{any}; } {
+  auto&& [_0] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<2>)
+requires requires { best::as_auto<decltype(val)>{any, any }; } {
+  auto&& [_0, _1] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<3>)
+requires requires { best::as_auto<decltype(val)>{any, any , any }; } {
+  auto&& [_0, _1, _2] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<4>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any }; } {
+  auto&& [_0, _1, _2, _3] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<5>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<6>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<7>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<8>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<9>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<10>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<11>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<12>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<13>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<14>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<15>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<16>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<17>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<18>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<19>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<20>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<21>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<22>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<23>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<24>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<25>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<26>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<27>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<28>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<29>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<30>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<31>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<32>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<33>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<34>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<35>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<36>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<37>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<38>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<39>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<40>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<41>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<42>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<43>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<44>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<45>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<46>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<47>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<48>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<49>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<50>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<51>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<52>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<53>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51), BEST_FWD(_52));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<54>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51), BEST_FWD(_52), BEST_FWD(_53));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<55>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51), BEST_FWD(_52), BEST_FWD(_53), BEST_FWD(_54));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<56>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51), BEST_FWD(_52), BEST_FWD(_53), BEST_FWD(_54), BEST_FWD(_55));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<57>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51), BEST_FWD(_52), BEST_FWD(_53), BEST_FWD(_54), BEST_FWD(_55), BEST_FWD(_56));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<58>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51), BEST_FWD(_52), BEST_FWD(_53), BEST_FWD(_54), BEST_FWD(_55), BEST_FWD(_56), BEST_FWD(_57));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<59>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51), BEST_FWD(_52), BEST_FWD(_53), BEST_FWD(_54), BEST_FWD(_55), BEST_FWD(_56), BEST_FWD(_57), BEST_FWD(_58));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<60>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51), BEST_FWD(_52), BEST_FWD(_53), BEST_FWD(_54), BEST_FWD(_55), BEST_FWD(_56), BEST_FWD(_57), BEST_FWD(_58), BEST_FWD(_59));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<61>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51), BEST_FWD(_52), BEST_FWD(_53), BEST_FWD(_54), BEST_FWD(_55), BEST_FWD(_56), BEST_FWD(_57), BEST_FWD(_58), BEST_FWD(_59), BEST_FWD(_60));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<62>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51), BEST_FWD(_52), BEST_FWD(_53), BEST_FWD(_54), BEST_FWD(_55), BEST_FWD(_56), BEST_FWD(_57), BEST_FWD(_58), BEST_FWD(_59), BEST_FWD(_60), BEST_FWD(_61));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<63>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51), BEST_FWD(_52), BEST_FWD(_53), BEST_FWD(_54), BEST_FWD(_55), BEST_FWD(_56), BEST_FWD(_57), BEST_FWD(_58), BEST_FWD(_59), BEST_FWD(_60), BEST_FWD(_61), BEST_FWD(_62));
+}
+constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<64>)
+requires requires { best::as_auto<decltype(val)>{any, any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any , any }; } {
+  auto&& [_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63] = BEST_FWD(val);
+  return best::call(BEST_FWD(cb), BEST_FWD(_0), BEST_FWD(_1), BEST_FWD(_2), BEST_FWD(_3), BEST_FWD(_4), BEST_FWD(_5), BEST_FWD(_6), BEST_FWD(_7), BEST_FWD(_8), BEST_FWD(_9), BEST_FWD(_10), BEST_FWD(_11), BEST_FWD(_12), BEST_FWD(_13), BEST_FWD(_14), BEST_FWD(_15), BEST_FWD(_16), BEST_FWD(_17), BEST_FWD(_18), BEST_FWD(_19), BEST_FWD(_20), BEST_FWD(_21), BEST_FWD(_22), BEST_FWD(_23), BEST_FWD(_24), BEST_FWD(_25), BEST_FWD(_26), BEST_FWD(_27), BEST_FWD(_28), BEST_FWD(_29), BEST_FWD(_30), BEST_FWD(_31), BEST_FWD(_32), BEST_FWD(_33), BEST_FWD(_34), BEST_FWD(_35), BEST_FWD(_36), BEST_FWD(_37), BEST_FWD(_38), BEST_FWD(_39), BEST_FWD(_40), BEST_FWD(_41), BEST_FWD(_42), BEST_FWD(_43), BEST_FWD(_44), BEST_FWD(_45), BEST_FWD(_46), BEST_FWD(_47), BEST_FWD(_48), BEST_FWD(_49), BEST_FWD(_50), BEST_FWD(_51), BEST_FWD(_52), BEST_FWD(_53), BEST_FWD(_54), BEST_FWD(_55), BEST_FWD(_56), BEST_FWD(_57), BEST_FWD(_58), BEST_FWD(_59), BEST_FWD(_60), BEST_FWD(_61), BEST_FWD(_62), BEST_FWD(_63));
+}

--- a/best/meta/internal/reflect_bind.sh
+++ b/best/meta/internal/reflect_bind.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Simple shell script that generates the boilerplate for reflect_internal::bind.
+#
+# Run with best/meta/internal/reflect_bind.sh > best/meta/internal/reflect_bind.inc
+
+MAX_LEN=64
+
+echo "// GENERATED CODE! DO NOT EDIT! See reflect_bind.sh."
+echo "#define BEST_REFLECT_MAX_FIELDS_ $MAX_LEN"
+
+# The code below doesn't handle the 0 and 1 cases quite right.
+echo "constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<0>)"
+echo "requires requires { best::as_auto<decltype(val)>{}; } {"
+echo "  return BEST_FWD(cb)();"
+echo "}"
+
+echo "constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<1>)"
+echo "requires requires { best::as_auto<decltype(val)>{any}; } {"
+echo "  auto&& [_0] = BEST_FWD(val);"
+echo "  return (BEST_FWD(cb))(BEST_FWD(_0));"
+echo "}"
+
+for i in $(seq 1 $(($MAX_LEN - 1))); do
+  anys="$(seq 1 $i | xargs printf ', any %.0s')"
+  ints="$(seq 1 $i | xargs printf ', _%s')"
+  fwds="$(seq 1 $i | xargs printf ', BEST_FWD(_%s)')"
+  echo "constexpr decltype(auto) bind(auto&& val, auto&& cb, rank<$(($i + 1))>)"
+  echo "requires requires { best::as_auto<decltype(val)>{any$anys}; } {"
+  echo "  auto&& [_0$ints] = BEST_FWD(val);"
+  echo "  return (BEST_FWD(cb))(BEST_FWD(_0)$fwds);"
+  echo "}"
+done

--- a/best/meta/internal/tlist.h
+++ b/best/meta/internal/tlist.h
@@ -201,7 +201,7 @@ using scatter =
 // 1, 2, 0, 1, 2}`: for each list `l`, the sequence `{.count = l.size() - 1}`.
 template <size_t total, typename... Packs>
 constexpr inline auto join_lut = [] {
-  std::array<size_t, total * 2> lut;
+  std::array<size_t, total * 2> lut = {};
 
   size_t running_total = 0;
   size_t list = 0;
@@ -263,6 +263,10 @@ concept ts_callable = best::callable<F, void(), Elems...>;
 
 template <typename F, typename... Elems>
 concept vs_callable =
+    sizeof...(Elems) > 0 && requires(F f) { best::call(f, Elems{}...); };
+
+template <typename F, typename... Elems>
+concept tvs_callable =
     sizeof...(Elems) > 0 && requires(F f) { best::call(f, Elems::value...); };
 
 }  // namespace best::tlist_internal

--- a/best/meta/names.h
+++ b/best/meta/names.h
@@ -1,0 +1,164 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_META_NAMES_H_
+#define BEST_META_NAMES_H_
+
+#include <type_traits>
+
+#include "best/meta/internal/names.h"
+#include "best/text/str.h"
+
+//! Name reflection.
+//!
+//! Utilities for obtaining the names of C++ program entities, such as types and
+//! enum variants.
+
+namespace best {
+/// # `best::type_names`
+///
+/// The pretty-printed names of some type. This type provides access to the name
+/// of a type in various formats; generally, you'll want the "good default" of
+/// `best::type_name`.
+class type_names final {
+ public:
+  /// # `type_names::of<T>`
+  ///
+  /// Extracts the names of tye type `T`.
+  template <typename T>
+  static const type_names of;
+
+  /// # `type_names::name()`
+  ///
+  /// Returns this type's identifier, i.e., without its path prefix or its
+  /// template parameters.
+  ///
+  /// This is what gets used for debug printing by default.
+  constexpr best::str name() const {
+    return full_name_[{.start = last_colcol_, .end = first_angle_}];
+  }
+
+  /// # `type_names::path()`
+  ///
+  /// Returns this type's full path (but not its template parameters).
+  constexpr best::str path() const { return full_name_[{.end = first_angle_}]; }
+
+  /// # `type_names::name_space()`
+  ///
+  /// Returns this type's containing namespace. May be empty.
+  constexpr best::str name_space() const {
+    return full_name_[{.end = best::saturating_sub(last_colcol_, 2)}];
+  }
+
+  /// # `type_names::namespace_()`
+  ///
+  /// Returns this type's template parameters. May be empty.
+  constexpr best::str params() const {
+    return full_name_[{.start = first_angle_}];
+  }
+
+  /// # `type_names::template_ident()`
+  ///
+  /// Returns this type's identifier with template parameters.
+  constexpr best::str name_with_params() const {
+    return full_name_[{.start = last_colcol_}];
+  }
+
+  /// # `type_names::full()`
+  ///
+  /// Returns this type's full path with template parameters.
+  constexpr best::str path_with_params() const { return full_name_; }
+
+ private:
+  constexpr explicit type_names(best::str name);
+  best::str full_name_;
+  size_t last_colcol_, first_angle_;
+};
+
+/// # `best::type_name<T>`
+///
+/// The short name of a type. To access longer versions of this name, use
+/// `best::type_names::of<T>`.
+template <typename T>
+inline constexpr best::str type_name =
+    [] { return best::type_names::of<T>.ident(); }();
+
+/// # `best::field_name<T>
+///
+/// The name of a field represented by a pointer-to-member.
+template <auto pm>
+  requires std::is_member_pointer_v<decltype(pm)>
+inline constexpr best::str field_name = [] {
+  auto offsets = names_internal::FieldOffsets;
+  auto raw = names_internal::raw_name<pm>();
+  auto name =
+      best::str(unsafe("the compiler made this string, it better be UTF-8"),
+                raw[{
+                    .start = offsets.prefix,
+                    .count = raw.size() - offsets.prefix - offsets.suffix,
+                }]);
+
+  // `name` is going to be scoped, so we need to strip off a leading path.
+  return names_internal::remove_namespace(name);
+}();
+
+/// # `best::value_name<T>
+///
+/// The name of an enum value, if `e` refers to a named enumerator.
+template <auto e>
+inline constexpr best::option<best::str> value_name = [] {
+  auto offsets = names_internal::ValueOffsets;
+  auto raw = names_internal::raw_name<e>();
+  auto name =
+      best::str(unsafe("the compiler made this string, it better be UTF-8"),
+                raw[{
+                    .start = offsets.prefix,
+                    .count = raw.size() - offsets.prefix - offsets.suffix,
+                }]);
+
+  // `name` is going to be scoped, so we need to strip off a leading path.
+  return names_internal::remove_namespace(name);
+}();
+}  // namespace best
+
+/* ////////////////////////////////////////////////////////////////////////// *\
+ * ////////////////// !!! IMPLEMENTATION DETAILS BELOW !!! ////////////////// *
+\* ////////////////////////////////////////////////////////////////////////// */
+
+namespace best {
+constexpr type_names::type_names(best::str name) : full_name_(name) {
+  first_angle_ = full_name_.find('<').value_or(full_name_.size());
+
+  last_colcol_ = first_angle_ - names_internal::remove_namespace(
+                                    full_name_[{.end = first_angle_}])
+                                    .size();
+}
+
+template <typename T>
+inline constexpr type_names type_names::of{[] {
+  auto offsets = names_internal::TypeOffsets;
+  auto raw = names_internal::raw_name<T>();
+  return best::str(unsafe("the compiler made this string, it better be UTF-8"),
+                   raw[{
+                       .start = offsets.prefix,
+                       .count = raw.size() - offsets.prefix - offsets.suffix,
+                   }]);
+}()};
+}  // namespace best
+#endif  // BEST_META_REFLECT_H_

--- a/best/meta/names.h
+++ b/best/meta/names.h
@@ -99,8 +99,10 @@ inline constexpr best::str type_name = type_names::of<T>.name();
 template <best::is_member_ptr auto pm>
 inline constexpr best::str field_name = best::names_internal::parse<pm>();
 template <best::is_enum auto e>
-inline constexpr best::option<best::str> value_name =
-    best::names_internal::parse<e>();
+inline constexpr best::option<best::str> value_name = BEST_PUSH_GCC_DIAGNOSTIC()
+    BEST_IGNORE_GCC_DIAGNOSTIC("-Wenum-constexpr-conversion")
+        best::names_internal::parse<e>();
+BEST_POP_GCC_DIAGNOSTIC()
 }  // namespace best
 
 /* ////////////////////////////////////////////////////////////////////////// *\

--- a/best/meta/names_test.cc
+++ b/best/meta/names_test.cc
@@ -1,0 +1,50 @@
+
+#include "best/meta/names.h"
+#include "best/test/test.h"
+
+namespace best::names_test {
+struct Something {};
+
+template <typename T>
+struct WithParams {};
+
+best::test Types = [](auto& t) {
+  t.expect_eq(best::type_names::of<Something>.name(), "Something");
+  t.expect_eq(best::type_names::of<Something>.path(),
+              "best::names_test::Something");
+  t.expect_eq(best::type_names::of<Something>.name_space(),
+              "best::names_test");
+  t.expect_eq(best::type_names::of<Something>.params(), "");
+  t.expect_eq(best::type_names::of<Something>.name_with_params(), "Something");
+  t.expect_eq(best::type_names::of<Something>.path_with_params(),
+              "best::names_test::Something");
+
+  t.expect_eq(best::type_names::of<WithParams<int>>.name(), "WithParams");
+  t.expect_eq(best::type_names::of<WithParams<int>>.path(),
+              "best::names_test::WithParams");
+  t.expect_eq(best::type_names::of<WithParams<int>>.name_space(),
+              "best::names_test");
+  t.expect_eq(best::type_names::of<WithParams<int>>.params(), "<int>");
+  t.expect_eq(best::type_names::of<WithParams<int>>.name_with_params(),
+              "WithParams<int>");
+  t.expect_eq(best::type_names::of<WithParams<int>>.path_with_params(),
+              "best::names_test::WithParams<int>");
+};
+
+struct Struct {
+  int foo;
+  int bar();
+};
+
+best::test Members = [](auto& t) {
+  t.expect_eq(best::field_name<&Struct::foo>, "foo");
+  t.expect_eq(best::field_name<&Struct::bar>, "bar");
+};
+
+enum Foo { A };
+enum class Bar { B };
+best::test Enums = [](auto& t) {
+  t.expect_eq(best::value_name<A>, "A");
+  t.expect_eq(best::value_name<Bar::B>, "B");
+};
+}  // namespace best::names_test

--- a/best/meta/names_test.cc
+++ b/best/meta/names_test.cc
@@ -1,5 +1,24 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
 
 #include "best/meta/names.h"
+
 #include "best/test/test.h"
 
 namespace best::names_test {
@@ -12,8 +31,7 @@ best::test Types = [](auto& t) {
   t.expect_eq(best::type_names::of<Something>.name(), "Something");
   t.expect_eq(best::type_names::of<Something>.path(),
               "best::names_test::Something");
-  t.expect_eq(best::type_names::of<Something>.name_space(),
-              "best::names_test");
+  t.expect_eq(best::type_names::of<Something>.name_space(), "best::names_test");
   t.expect_eq(best::type_names::of<Something>.params(), "");
   t.expect_eq(best::type_names::of<Something>.name_with_params(), "Something");
   t.expect_eq(best::type_names::of<Something>.path_with_params(),

--- a/best/meta/reflect.h
+++ b/best/meta/reflect.h
@@ -1,0 +1,412 @@
+#ifndef BEST_META_REFLECT_H_
+#define BEST_META_REFLECT_H_
+
+#include "best/container/row.h"
+#include "best/meta/internal/reflect.h"
+#include "best/meta/taxonomy.h"
+#include "best/text/str.h"
+
+//! Struct and enum reflection.
+//!
+//! `best` provides a mechanism for reflecting the fields and variants of
+//! user-defined structs and enums, which must define the `BestReflect()`
+//! FTADLE:
+//!
+//! ```
+//! friend constexpr auto BestReflect(auto& mirror, MyStruct*) {
+//!   return mirror.reflect(
+//!     "MyStruct",
+//!     mirror.field("foo", &MyStruct::foo),
+//!     mirror.field("bar", &MyStruct::bar),
+//!   );
+//! }
+//! ```
+
+namespace best {
+
+/// # `best::reflected`, `best::is_reflected_struct`,
+///   `best::is_reflected_enum`
+///
+/// Whether `T` can be reflected, i.e., it is a struct or enum type that has a
+/// working `BestReflect()` FTADLE implementation.
+template <typename T>
+concept reflected = requires(const best::mirror& m, best::as_auto<T>* ptr) {
+  {
+    BestReflect(m, ptr)
+  } -> reflect_internal::valid_reflection<best::as_auto<T>>;
+};
+template <typename T>
+concept is_reflected_struct =
+    best::is_struct<best::as_auto<T>> && best::reflected<T>;
+template <typename T>
+concept is_reflected_enum =
+    best::is_enum<best::as_auto<T>> && best::reflected<T>;
+
+/// # `best::reflect<T>`
+///
+/// Obtains a reflection of a reflected type. This will be a value of the type
+/// `best::reflected_type`, although the exact specialization is not nameable.
+template <best::reflected T>
+inline constexpr auto reflect =
+    best::reflected_type<reflect_internal::info<best::as_auto<T>>>{};
+
+/// # `best::mirror`
+///
+/// A value of this type is passed to the `BestReflect` FTADLE. This type
+/// cannot be constructed by users and exists only for exposition.
+class mirror final {
+ public:
+  /// # `mirror()`
+  ///
+  /// Reflects that there exists a type with the given name, the given members,
+  /// and optionally, a row of tag types.
+  constexpr auto operator()(best::str name, auto... members) const;
+  constexpr auto operator()(best::str name, best::is_row auto tags,
+                            auto... members) const;
+
+  /// # `mirror.field()`
+  ///
+  /// Reflects that `Struct` has a data member with the given name, the
+  /// given type, and optionally, a row of tag types. The result of this call
+  /// should be passed to `reflect()`.
+  template <best::is_struct Struct, best::is_object Type>
+  constexpr auto field(best::str name, Type Struct::*member,
+                       auto... tags) const;
+
+  /// # `mirror.value()`
+  ///
+  /// Reflects that Enum `Struct` has an enumerator with the given name, the
+  /// given value, and optionally, a row of tag types. The result of this call
+  /// should be passed to `reflect()`.
+  template <best::is_enum Enum>
+  constexpr auto value(best::str name, Enum value, auto... tags) const;
+
+  mirror(const mirror&) = delete;
+  mirror& operator=(const mirror&) = delete;
+
+ private:
+  constexpr mirror() = default;
+
+ public:
+  static const mirror BEST_MIRROR_FTADLE_;
+};
+inline constexpr mirror mirror::BEST_MIRROR_FTADLE_{};
+#define BEST_MIRROR_FTADLE_ _private
+
+/// # `best::reflected_field`
+///
+/// A field of some reflected struct. The type parameter is an implementation
+/// detail; this type cannot be instantiated by users.
+///
+/// A `best::reflected_field` offers accessors for information about the field,
+/// such as its name, access to a member-to-ptr, and so on.
+///
+/// A field can also be used to offset into a struct, with the syntax
+/// `my_struct->*field`. `my_struct` can be a reference or pointer to
+/// the reflected type, or a dereferenceable type that returns one.
+template <auto& info_>
+class reflected_field final {
+ private:
+  static_assert(info_.Kind == reflect_internal::Field,
+                "cannot instantiate best::reflected_field directly");
+  using info_t = best::as_auto<decltype(info_)>;
+
+ public:
+  /// # `reflected_field::reflected`
+  ///
+  /// The type this field was reflected from.
+  using reflected = info_t::struct_;
+
+  /// # `reflected_field::type`
+  ///
+  /// The type of this field.
+  using type = info_t::type;
+
+  /// # `reflected_field::name()`
+  ///
+  /// Returns the name of this field as specified in the `BestReflect()` call.
+  constexpr best::str name() const { return info_.name_; }
+
+  /// # `reflected_field::tags()`
+  ///
+  /// Returns any tags on this field that can be selected by `Key`.
+  template <typename Key>
+  constexpr best::is_row auto tags(best::tlist<Key> key = {}) const {
+    return info_.tags_.select(key);
+  }
+
+  /// # `reflected_field::as_offset()`
+  ///
+  /// Returns a pointer-to-member that represents this field.
+  constexpr type reflected::*as_offset() const { return info_.ptr_; }
+
+  constexpr friend decltype(auto) operator->*(auto&& r, reflected_field f)
+    requires best::same<best::as_auto<decltype(r)>, reflected>
+  {
+    return BEST_FWD(r).*(f.as_offset());
+  }
+  constexpr friend decltype(auto) operator->*(
+      best::is_deref<reflected> auto&& r, reflected_field f) {
+    return (*BEST_FWD(r)).*(f.as_offset());
+  }
+
+ private:
+  template <auto&>
+  friend class reflected_type;
+};
+
+/// # `best::reflected_value`
+///
+/// A value of some reflected enum. The type parameter is an implementation
+/// detail; this type cannot be instantiated by users.
+///
+/// A `best::reflected_value` offers accessors for information about the field,
+/// such as its name, access to the enum value itself, and so on.
+template <auto& info_>
+class reflected_value final {
+ private:
+  static_assert(info_.Kind == reflect_internal::Value,
+                "cannot instantiate best::reflected_value directly");
+  using info_t = best::as_auto<decltype(info_)>;
+
+ public:
+  /// # `reflected_field::reflected`
+  ///
+  /// The type this field was reflected from.
+  using reflected = info_t::enum_;
+
+  /// # `reflected_field::value`
+  ///
+  /// The actual reflected value.
+  static constexpr reflected value = info_.elem_;
+
+  /// # `reflected_field::name()`
+  ///
+  /// Returns the name of this field as specified in the `BestReflect()` call.
+  constexpr best::str name() const { return info_.name_; }
+
+  /// # `reflected_field::tags()`
+  ///
+  /// Returns any tags on this field that can be selected by `Key`.
+  template <typename Key>
+  constexpr best::is_row auto tags(best::tlist<Key> key = {}) const {
+    return info_.tags_.select(key);
+  }
+
+ private:
+  template <auto&>
+  friend class reflected_type;
+};
+
+/// # `best::reflected_type`
+///
+/// The result of reflecting a type. The type parameter is an implementation
+/// detail; this type cannot be instantiated by users.
+///
+/// To obtain an instance of this type, use `best::reflect<T>`.
+template <auto& info_>
+class reflected_type final {
+ private:
+  static_assert(info_.Kind == reflect_internal::Struct ||
+                    info_.Kind == reflect_internal::Enum ||
+                    info_.Kind == reflect_internal::NoFields,
+                "cannot instantiate best::field directly");
+  using info_t = best::as_auto<decltype(info_)>;
+
+ public:
+  /// # `reflected_type::reflected`
+  ///
+  /// The type this is a reflection of.
+  using reflected =
+      best::select<info_.Kind == reflect_internal::Struct,
+                   typename info_t::struct_, typename info_t::enum_>;
+
+  /// # `reflected_type::name()`
+  ///
+  /// Returns the name of this type as specified in the `BestReflect()` call.
+  constexpr best::str name() const { return info_.name_; }
+
+  /// # `reflected_type::find(member)`
+  ///
+  /// Looks up the field or value corresponding to a particular member. This
+  /// the member should be a pointer-to-member if this is a reflects a struct,
+  /// or a value of the underlying enum if this reflects an enum.
+  ///
+  /// It will then call `cb` with the appropriate value. Internally, it has the
+  /// semantics of calling `best::choice::match()` on a choice that can contain
+  /// any of the possible reflected field/value types produced by fields() or
+  /// values(), respectively. If no element matches, it is as if the selected
+  /// element has type `void`.
+  ///
+  /// Hence, the best way to use this function is to write something like this.
+  ///
+  /// ```
+  /// auto name = best::reflect<T>.find(xyz,
+  ///   [](auto value) { return value.name() },
+  ///   [] { return best::str("<unknown>"); });
+  /// ```
+  constexpr decltype(auto) find(auto member, auto&&... cases) const;
+
+  /// # `reflected_type::tags()`
+  ///
+  /// Returns any tags on this type that can be selected by `Key`.
+  template <typename Key>
+  constexpr best::is_row auto tags(best::tlist<Key> key = {}) const {
+    return info_.tags_.select(key);
+  }
+
+  /// # `reflected_type::fields()`
+  ///
+  /// Calls `cb` with a pack of `best::reflected_field`s for this type.
+  constexpr decltype(auto) fields(auto&& cb) const
+    requires best::is_struct<reflected>;
+
+  /// # `reflected_type::each_field(...)`
+  ///
+  /// Zips together the fields of a bunch of references-to-`reflected`, and
+  /// calls `cb` (the last argument of `args...`) on each row of fields.
+  constexpr void each_field(auto&&... args) const
+    requires best::is_struct<reflected>;
+
+  /// # `reflected_type::values()`
+  ///
+  /// Calls `cb` with a pack of `best::reflected_values`s for this type.
+  constexpr decltype(auto) values(auto&& cb) const
+    requires best::is_enum<reflected>;
+
+  constexpr reflected_type() = default;
+
+ private:
+  /// Workaround for a dumb Clang 17 conformance bug.
+  template <size_t i>
+  static constexpr auto item = info_.items_[best::index<i>];
+};
+
+/// # `best::fields()`
+///
+/// Extracts all of the fields out of a reflected struct and creates a row
+/// of references of them.
+constexpr auto fields(best::is_reflected_struct auto&& value) {
+  return best::reflect<decltype(value)>.fields(
+      [&](auto... f) { return best::row(best::bind, value->*f...); });
+}
+}  // namespace best
+
+/******************************************************************************/
+
+///////////////////// !!! IMPLEMENTATION DETAILS BELOW !!! /////////////////////
+
+/******************************************************************************/
+
+namespace best {
+constexpr auto mirror::operator()(best::str name, best::is_row auto tags,
+                                  auto... members) const {
+  if constexpr (sizeof...(members) == 0) {
+    return reflect_internal::no_fields<best::as_auto<decltype(tags)>>{name,
+                                                                      tags};
+  } else if constexpr (((members.Kind == reflect_internal::Field) && ...)) {
+    static_assert(
+        best::same<typename best::as_auto<decltype(members)>::struct_...>,
+        "all fields passed to a best::mirror must have the same "
+        "struct type");
+    using Struct =
+        best::tlist<typename best::as_auto<decltype(members)>::struct_...>::
+            template type<0>;
+    return best::reflect_internal::struct_info<
+        Struct, best::as_auto<decltype(tags)>,
+        best::as_auto<decltype(members)>...>{name, tags, {members...}};
+  } else if constexpr (((members.Kind == reflect_internal::Value) && ...)) {
+    static_assert(
+        best::same<typename best::as_auto<decltype(members)>::enum_...>,
+        "all values passed to best::mirror must have the same "
+        "enum type");
+    using Enum = best::tlist<
+        typename best::as_auto<decltype(members)>::enum_...>::template type<0>;
+    return best::reflect_internal::enum_info<
+        Enum, best::as_auto<decltype(tags)>,
+        best::as_auto<decltype(members)>...>{name, tags, {members...}};
+  } else {
+    static_assert(sizeof...(members) == 0,
+                  "passed invalid member values into the mirror");
+  }
+}
+constexpr auto mirror::operator()(best::str name, auto... members) const {
+  return operator()(name, row(), members...);
+}
+
+template <best::is_struct Struct, best::is_object Type>
+constexpr auto mirror::field(best::str name, Type Struct::*member,
+                             auto... tags) const {
+  return best::reflect_internal::field_info<Struct, Type,
+                                            best::as_auto<decltype(tags)>...>{
+      name, member, {tags...}};
+}
+
+template <best::is_enum Enum>
+constexpr auto mirror::value(best::str name, Enum value, auto... tags) const {
+  return best::reflect_internal::elem_info<Enum,
+                                           best::as_auto<decltype(tags)>...>{
+      name, value, {tags...}};
+}
+
+template <auto& info_>
+constexpr decltype(auto) reflected_type<info_>::find(auto member,
+                                                     auto&&... cases) const {
+  if constexpr (best::is_struct<reflected>) {
+    return fields([&](auto... fields) {
+      using Ch = best::choice<void, decltype(fields)...>;
+      Ch ch(best::index<0>);
+
+      ((best::equal(member, fields.as_offset()) ? void(ch = Ch(fields))
+                                                : void()),
+       ...);
+      return ch.match(BEST_FWD(cases)...);
+    });
+  } else {
+    return values([&](auto... values) {
+      using Ch = best::choice<void, decltype(values)...>;
+      Ch ch(best::index<0>);
+
+      ((best::equal(member, values.value) ? void(ch = Ch(values)) : void()),
+       ...);
+      return ch.match(BEST_FWD(cases)...);
+    });
+  }
+}
+
+template <auto& info_>
+constexpr decltype(auto) reflected_type<info_>::fields(auto&& cb) const
+  requires best::is_struct<reflected>
+{
+  return best::indices<info_.items_.types.size()>.apply([&]<typename... I> {
+    return best::call(BEST_FWD(cb), best::reflected_field<item<I::value>>{}...);
+  });
+}
+
+template <auto& info_>
+constexpr void reflected_type<info_>::each_field(auto&&... args) const
+  requires best::is_struct<reflected>
+{
+  if constexpr (sizeof...(args) == 1) {
+    fields([&](auto... fields) { (best::call(args..., fields), ...); });
+  } else {
+    best::row<decltype(args)...> row(BEST_FWD(args)...);
+    each_field([&](auto field) {
+      best::indices<info_.items_.types.size() - 1>.apply([&]<typename... I> {
+        best::call(BEST_MOVE(row).last(),
+                   BEST_MOVE(row)[best::index<I::value>]->*field...);
+      });
+    });
+  }
+}
+
+template <auto& info_>
+constexpr decltype(auto) reflected_type<info_>::values(auto&& cb) const
+  requires best::is_enum<reflected>
+{
+  return best::indices<info_.items_.types.size()>.apply([&]<typename... I> {
+    return best::call(BEST_FWD(cb), best::reflected_value<item<I::value>>{}...);
+  });
+}
+}  // namespace best
+#endif  // BEST_META_REFLECT_H_

--- a/best/meta/reflect_test.cc
+++ b/best/meta/reflect_test.cc
@@ -1,9 +1,38 @@
-#include "best/meta/reflect.h"
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
 
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+//#include "best/meta/reflect.h"
+
+#include "best/meta/internal/reflect.h"
 #include "best/test/test.h"
 
 namespace best::reflect_test {
-struct Tag {};
+struct Foo final {
+  int foo, bar, baz;
+};
+
+best::test t = [](auto& t) {
+  constexpr auto i = reflect_internal::infer_struct<Foo>().index<&Foo::bar>();
+  t.expect_eq(i, 1);
+};
+
+/*struct Tag {};
 
 template <typename F>
 struct MyCallback {
@@ -65,5 +94,5 @@ best::test FindTag = [](auto& t) {
       },
       [] { return 0; });
   t.expect_eq(found, 42);
-};
+};*/
 }  // namespace best::reflect_test

--- a/best/meta/reflect_test.cc
+++ b/best/meta/reflect_test.cc
@@ -1,0 +1,69 @@
+#include "best/meta/reflect.h"
+
+#include "best/test/test.h"
+
+namespace best::reflect_test {
+struct Tag {};
+
+template <typename F>
+struct MyCallback {
+  using BestRowKey = Tag;
+  F callback;
+};
+
+template <typename F>
+MyCallback(F) -> MyCallback<F>;
+
+struct MyType final {
+  int x, y, z;
+  best::str s1, s2;
+
+  constexpr friend auto BestReflect(auto& m, MyType*) {
+    return m("MyType",                                                 //
+             m.field("x", &MyType::x),                                 //
+             m.field("y", &MyType::y),                                 //
+             m.field("z", &MyType::z, MyCallback([] { return 42; })),  //
+             m.field("s1", &MyType::s1),                               //
+             m.field("s2", &MyType::s2));
+  }
+};
+
+static_assert(best::is_reflected_struct<MyType>);
+
+enum class MyEnum { A, B, C };
+constexpr auto BestReflect(auto& m, MyEnum*) {
+  return m("MyEnum",                 //
+           m.value("A", MyEnum::A),  //
+           m.value("B", MyEnum::B),  //
+           m.value("C", MyEnum::C));
+}
+
+static_assert(best::is_reflected_enum<MyEnum>);
+
+best::test ToString = [](auto& t) {
+  t.expect_eq(best::format("{:?}", MyType{1, 2, 3, "foo", "bar"}),
+              R"(MyType {x: 1, y: 2, z: 3, s1: "foo", s2: "bar"})");
+
+  t.expect_eq(best::format("{:?}, {:?}", MyEnum::B, MyEnum(42)),
+              "MyEnum::B, MyEnum(42)");
+};
+
+best::test Fields = [](auto& t) {
+  MyType x0{1, 2, 3, "foo", "bar"};
+  t.expect_eq(best::fields(x0), best::row(1, 2, 3, "foo", "bar"));
+};
+
+best::test FindTag = [](auto& t) {
+  int found = best::reflect<MyType>.find(
+      &MyType::z,
+      [](auto field) {
+        auto tags = field.tags(best::types<Tag>);
+        if constexpr (!tags.is_empty()) {
+          return tags[best::index<0>].callback();
+        }
+        return 0;
+      },
+      [] { return 0; });
+  t.expect_eq(found, 42);
+};
+}  // namespace best::reflect_test

--- a/best/meta/tags.h
+++ b/best/meta/tags.h
@@ -66,6 +66,14 @@ inline constexpr uninit_t uninit;
 /// *a* type to pass in that position, so that calling the FTADLE finds
 /// overloads in the best:: namespace, too.
 struct ftadle final {};
+
+namespace tags_internal_do_not_use {
+struct ctad_guard;
+#define BEST_CTAD_GUARD_(type_, Tag_)                                       \
+  static_assert(                                                            \
+      ::std::is_same_v<Tag_, ::best::tags_internal_do_not_use::ctad_guard>, \
+      "you may not instantiate " type_ " manually; please use CTAD instead")
+}  // namespace tags_internal_do_not_use
 }  // namespace best
 
 #endif  // BEST_META_TAGS_H_

--- a/best/meta/taxonomy.h
+++ b/best/meta/taxonomy.h
@@ -38,7 +38,7 @@ namespace best {
 ///
 /// Intended to improve compile times and gdb debugging by eliminating an
 /// extremely common function that must be inlined.
-#define BEST_FWD(expr_) (static_cast<decltype(expr_)>(expr_))
+#define BEST_FWD(expr_) (static_cast<decltype(expr_)&&>(expr_))
 
 /// # `BEST_MOVE()`
 ///

--- a/best/meta/taxonomy.h
+++ b/best/meta/taxonomy.h
@@ -202,6 +202,12 @@ using as_auto = std::remove_cvref_t<T>;
 template <typename T>
 concept is_ptr = std::is_pointer_v<T>;
 
+/// # `best::is_member_ptr`
+///
+/// Whether this is a pointer-to-member type.
+template <typename T>
+concept is_member_ptr = std::is_member_pointer_v<T>;
+
 /// # `best::as_ptr<T>`
 ///
 /// If `T` is an object, void, or tame function type, returns a pointer to it.
@@ -246,10 +252,9 @@ constexpr auto addr(auto&& ref) { return __builtin_addressof(ref); }
 /// # `best::is_struct`
 ///
 /// Identifies a "struct type". In our highly narrow definition, this is a
-/// final class type that is an aggregate.
+/// class type that is an aggregate.
 template <typename T>
-concept is_struct =
-    std::is_class_v<T> && std::is_aggregate_v<T> && std::is_final_v<T>;
+concept is_struct = std::is_class_v<T> && std::is_aggregate_v<T>;
 
 /// # `best::is_enum`
 ///

--- a/best/meta/taxonomy.h
+++ b/best/meta/taxonomy.h
@@ -38,7 +38,7 @@ namespace best {
 ///
 /// Intended to improve compile times and gdb debugging by eliminating an
 /// extremely common function that must be inlined.
-#define BEST_FWD(expr_) (static_cast<decltype(expr_)&&>(expr_))
+#define BEST_FWD(expr_) (static_cast<decltype(expr_)>(expr_))
 
 /// # `BEST_MOVE()`
 ///

--- a/best/meta/tlist.h
+++ b/best/meta/tlist.h
@@ -392,11 +392,11 @@ class tlist final {
   ///
   /// Applies `cb` to each type in this list as in `map()` but does not require
   /// that `cb` return a value.
-  static constexpr void each(tlist_internal::t_callable<Elems...> auto cb) {
-    (best::call<Elems>(cb), ...);
+  static constexpr void each(tlist_internal::t_callable<Elems...> auto&& cb) {
+    (best::call<Elems>(BEST_FWD(cb)), ...);
   }
-  static constexpr void each(tlist_internal::v_callable<Elems...> auto cb) {
-    (best::call(cb, Elems::value), ...);
+  static constexpr void each(tlist_internal::v_callable<Elems...> auto&& cb) {
+    (best::call(BEST_FWD(cb), Elems::value), ...);
   }
 
   /// # `tlist::apply()`
@@ -404,12 +404,12 @@ class tlist final {
   /// Applies `cb` to *every* type in this list at once. `cb` may either have
   /// a `typename...` parameter or an `auto...` argument.
   static constexpr decltype(auto) apply(
-      tlist_internal::ts_callable<Elems...> auto cb) {
-    return best::call<Elems...>(cb);
+      tlist_internal::ts_callable<Elems...> auto&& cb) {
+    return best::call<Elems...>(BEST_FWD(cb));
   }
   static constexpr decltype(auto) apply(
-      tlist_internal::vs_callable<Elems...> auto cb) {
-    return best::call(cb, Elems::value...);
+      tlist_internal::vs_callable<Elems...> auto&& cb) {
+    return best::call(BEST_FWD(cb), Elems::value...);
   };
   template <template <typename...> typename Trait>
   static constexpr Trait<Elems...> apply() {

--- a/best/test/test.cc
+++ b/best/test/test.cc
@@ -64,7 +64,7 @@ bool test::run_all(int argc, char** argv) {
   best::eprint("{}testing:", Bold);
 
   for (int i = 0; i < argc; ++i) {
-    best::eprint(" {}", argv[i]);
+    best::eprint(" {}", *str::from_nul(argv[i]));
   }
   best::eprintln();
   best::eprintln("executing {} test(s)\n", all_tests.size());

--- a/best/text/BUILD
+++ b/best/text/BUILD
@@ -79,6 +79,7 @@ cc_library(
     "//best/container:span",
     "//best/math:conv",
     "//best/meta:guard",
+    "//best/meta:reflect",
   ]
 )
 

--- a/best/text/internal/format_impls.h
+++ b/best/text/internal/format_impls.h
@@ -23,7 +23,7 @@
 #include <cstddef>
 #include <type_traits>
 
-#include "best/meta/reflect.h"
+// #include "best/meta/reflect.h"
 #include "best/text/rune.h"
 #include "best/text/str.h"
 
@@ -184,6 +184,7 @@ constexpr void BestFmtQuery(auto& query, R* range)
   query.requires_debug = false;
 }
 
+#if 0
 void BestFmt(auto& fmt, const best::is_reflected_struct auto& value) {
   auto refl = best::reflect<decltype(value)>;
   auto rec = fmt.record(refl.name());
@@ -200,6 +201,7 @@ void BestFmt(auto& fmt, const best::is_reflected_enum auto& value) {
         fmt.format("{}({})", refl.name(), U(value));
       });
 }
+#endif
 
 namespace format_internal {
 using mark_as_used = void;

--- a/best/text/internal/format_impls.h
+++ b/best/text/internal/format_impls.h
@@ -21,7 +21,9 @@
 #define BEST_TEXT_INTERNAL_FORMAT_IMPLS_H_
 
 #include <cstddef>
+#include <type_traits>
 
+#include "best/meta/reflect.h"
 #include "best/text/rune.h"
 #include "best/text/str.h"
 
@@ -180,6 +182,23 @@ constexpr void BestFmtQuery(auto& query, R* range)
 {
   query = query.template of<decltype(*std::begin(*range))>;
   query.requires_debug = false;
+}
+
+void BestFmt(auto& fmt, const best::is_reflected_struct auto& value) {
+  auto refl = best::reflect<decltype(value)>;
+  auto rec = fmt.record(refl.name());
+  refl.fields(
+      [&](auto... field) { (rec.field(field.name(), value->*field), ...); });
+}
+
+void BestFmt(auto& fmt, const best::is_reflected_enum auto& value) {
+  auto refl = best::reflect<decltype(value)>;
+  refl.find(
+      value, [&](auto& val) { fmt.format("{}::{}", refl.name(), val.name()); },
+      [&] {
+        using U = std::underlying_type_t<best::as_auto<decltype(value)>>;
+        fmt.format("{}({})", refl.name(), U(value));
+      });
 }
 
 namespace format_internal {

--- a/best/text/internal/format_impls.h
+++ b/best/text/internal/format_impls.h
@@ -23,7 +23,7 @@
 #include <cstddef>
 #include <type_traits>
 
-// #include "best/meta/reflect.h"
+#include "best/meta/reflect.h"
 #include "best/text/rune.h"
 #include "best/text/str.h"
 
@@ -184,24 +184,25 @@ constexpr void BestFmtQuery(auto& query, R* range)
   query.requires_debug = false;
 }
 
-#if 0
-void BestFmt(auto& fmt, const best::is_reflected_struct auto& value) {
+void BestFmt(auto& fmt, const best::is_reflected_struct auto& value)
+  requires(!requires { fmt.format(*std::begin(value)); })
+{
   auto refl = best::reflect<decltype(value)>;
   auto rec = fmt.record(refl.name());
-  refl.fields(
+  refl.apply(
       [&](auto... field) { (rec.field(field.name(), value->*field), ...); });
 }
 
 void BestFmt(auto& fmt, const best::is_reflected_enum auto& value) {
   auto refl = best::reflect<decltype(value)>;
-  refl.find(
-      value, [&](auto& val) { fmt.format("{}::{}", refl.name(), val.name()); },
+  refl.match(
+      value,  //
+      [&](auto val) { fmt.format("{}::{}", refl.name(), val.name()); },
       [&] {
         using U = std::underlying_type_t<best::as_auto<decltype(value)>>;
         fmt.format("{}({})", refl.name(), U(value));
       });
 }
-#endif
 
 namespace format_internal {
 using mark_as_used = void;

--- a/best/text/internal/format_parser_test.cc
+++ b/best/text/internal/format_parser_test.cc
@@ -23,20 +23,6 @@
 #include "best/test/test.h"
 #include "best/text/format.h"
 
-namespace best {
-void BestFmt(auto& fmt, const format_spec& spec) {
-  auto rec = fmt.record();
-  rec.field("alt", spec.alt);
-  rec.field("debug", spec.debug);
-  rec.field("sign_aware_padding", spec.sign_aware_padding);
-  rec.field("alignment", best::option<int>(spec.alignment));
-  rec.field("fill", spec.fill);
-  rec.field("width", spec.width);
-  rec.field("prec", spec.prec);
-  rec.field("method", spec.method);
-}
-}  // namespace best
-
 namespace best::format_internal::parser_test {
 using Node = best::choice<best::str, best::row<size_t, best::format_spec>>;
 using Ast = best::vec<Node>;

--- a/best/text/str.h
+++ b/best/text/str.h
@@ -106,7 +106,8 @@ class text final {
   /// # `text::text()`
   ///
   /// Creates a new, empty string with the given encoding.
-  constexpr explicit text(encoding enc = {})
+  constexpr text() : text(encoding{}) {}
+  constexpr explicit text(encoding enc)
       : text(in_place, best::span(&empty, 0), std::move(enc)) {}
 
   /// # `text::text(text)`


### PR DESCRIPTION
This change adds a very basic struct and enum reflection framework, which I will use to build a CLI flags parser on top of.
This adds:

- `best::mirror`, `best::reflect`, and friends.
- `best::is_struct` and `best::is_enum`.
- `best::row::select()`, for pulling out specific elements of a generic row by type or key. 
- `best::type_name<T>` and friends.
- `best::row::as_ref()`
- `best::is_member_ptr<T>`
- `best::tap`, for constructing `->*` helpers.