### PR TITLE
All the row operations: `best::{tlist, row}::{at, join, push, insert, splice, remove, erase, gather, scatter}`

### DIFF
--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -55,7 +55,7 @@ struct err;
 template <typename...>
 class row;
 template <typename...>
-struct row_forward;
+struct fwd;
 
 // best/container/pun.h
 template <typename...>

--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -55,7 +55,7 @@ struct err;
 template <typename...>
 class row;
 template <typename...>
-struct fwd;
+struct args;
 
 // best/container/pun.h
 template <typename...>

--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -85,6 +85,8 @@ template <auto&>
 class reflected_type;
 
 // best/meta/tlist.h
+template <auto>
+struct val;
 template <typename...>
 class tlist;
 

--- a/best/container/BUILD
+++ b/best/container/BUILD
@@ -154,6 +154,7 @@ cc_test(
   deps = [
     ":row",
     "//best/test",
+    "//best/test:fodder",
   ],
 )
 

--- a/best/container/internal/pun.h
+++ b/best/container/internal/pun.h
@@ -24,6 +24,7 @@
 #include "best/container/object.h"
 #include "best/meta/init.h"
 #include "best/meta/tags.h"
+#include "best/meta/tlist.h"
 
 //! Internal implementation of best::pun.
 

--- a/best/container/object.h
+++ b/best/container/object.h
@@ -263,10 +263,10 @@ class object_ptr final {
   }
   template <typename... Args>
   BEST_INLINE_SYNTHETIC constexpr void construct_in_place(
-      best::fwd<Args...> args) const
+      best::args<Args...> args) const
     requires best::constructible<T, Args...>
   {
-    args.args.apply(
+    args.row.apply(
         [&](auto&&... args) { construct_in_place(BEST_FWD(args)...); });
   }
 
@@ -333,7 +333,7 @@ class object_ptr final {
     }
   }
   template <typename... Args>
-  BEST_INLINE_SYNTHETIC constexpr void assign(best::fwd<Args...> args) const
+  BEST_INLINE_SYNTHETIC constexpr void assign(best::args<Args...> args) const
     requires best::constructible<T, Args...>
   {
     args.row.apply([&](auto&&... args) { assign(BEST_FWD(args)...); });

--- a/best/container/object.h
+++ b/best/container/object.h
@@ -263,10 +263,10 @@ class object_ptr final {
   }
   template <typename... Args>
   BEST_INLINE_SYNTHETIC constexpr void construct_in_place(
-      best::row_forward<Args...> args) const
+      best::fwd<Args...> args) const
     requires best::constructible<T, Args...>
   {
-    args.row.apply(
+    args.args.apply(
         [&](auto&&... args) { construct_in_place(BEST_FWD(args)...); });
   }
 
@@ -333,8 +333,7 @@ class object_ptr final {
     }
   }
   template <typename... Args>
-  BEST_INLINE_SYNTHETIC constexpr void assign(
-      best::row_forward<Args...> args) const
+  BEST_INLINE_SYNTHETIC constexpr void assign(best::fwd<Args...> args) const
     requires best::constructible<T, Args...>
   {
     args.row.apply([&](auto&&... args) { assign(BEST_FWD(args)...); });

--- a/best/container/pun.h
+++ b/best/container/pun.h
@@ -24,7 +24,6 @@
 #include "best/container/internal/pun.h"
 #include "best/container/object.h"
 #include "best/meta/init.h"
-#include "best/meta/tags.h"
 #include "best/meta/tlist.h"
 
 //! Untagged unions that are somewhat sensible.

--- a/best/container/result.h
+++ b/best/container/result.h
@@ -43,17 +43,17 @@ namespace best {
 /// ```
 template <typename... Args>
 struct ok {
-  constexpr ok(Args... args) : row(BEST_FWD(args)...) {}
-  best::row<Args...> row;
+  constexpr ok(Args... args) : args(BEST_FWD(args)...) {}
+  best::fwd<Args...> args;
 
   friend void BestFmt(auto& fmt, const ok& ok)
-    requires requires { fmt.format(ok.row); }
+    requires requires { fmt.format(ok.args); }
   {
     fmt.write("ok");
-    fmt.format(ok.row);
+    fmt.format(ok.args);
   }
   friend constexpr void BestFmtQuery(auto& query, ok*) {
-    query = query.template of<best::row<Args...>>;
+    query = query.template of<best::fwd<Args...>>;
   }
 };
 template <typename... Args>
@@ -70,17 +70,17 @@ ok(Args&&...) -> ok<Args&&...>;
 /// ```
 template <typename... Args>
 struct err {
-  constexpr err(Args... args) : row(BEST_FWD(args)...) {}
-  best::row<Args...> row;
+  constexpr err(Args... args) : args(BEST_FWD(args)...) {}
+  best::fwd<Args...> args;
 
   friend void BestFmt(auto& fmt, const err& err)
-    requires requires { fmt.format(err.row); }
+    requires requires { fmt.format(err.args); }
   {
     fmt.write("err");
-    fmt.format(err.row);
+    fmt.format(err.args);
   }
   friend constexpr void BestFmtQuery(auto& query, err*) {
-    query = query.template of<best::row<Args...>>;
+    query = query.template of<best::fwd<Args...>>;
   }
 };
 template <typename... Args>
@@ -167,7 +167,7 @@ class [[nodiscard(
   template <typename... Args>
   constexpr result(best::ok<Args...> args)
     requires best::constructible<T, Args...>
-      : BEST_RESULT_IMPL_(best::index<0>, std::move(args).row.forward()) {}
+      : BEST_RESULT_IMPL_(best::index<0>, std::move(args).args) {}
 
   /// # `result::result(err(...))`
   ///
@@ -175,7 +175,7 @@ class [[nodiscard(
   template <typename... Args>
   constexpr result(best::err<Args...> args)
     requires best::constructible<E, Args...>
-      : BEST_RESULT_IMPL_(best::index<1>, std::move(args).row.forward()) {}
+      : BEST_RESULT_IMPL_(best::index<1>, std::move(args).args) {}
 
   /// # `result::result(result<U, F>&)`
   ///
@@ -282,11 +282,11 @@ class [[nodiscard(
   }
   template <best::equatable<T> U>
   BEST_INLINE_SYNTHETIC constexpr bool operator==(best::ok<U> u) const {
-    return ok() == u.row[best::index<0>];
+    return ok() == u.args.args[best::index<0>];
   }
   template <best::equatable<E> U>
   BEST_INLINE_SYNTHETIC constexpr bool operator==(best::err<U> u) const {
-    return err() == u.row[best::index<0>];
+    return err() == u.args.args[best::index<0>];
   }
 
   BEST_INLINE_SYNTHETIC constexpr bool operator==(best::ok<> u) const {
@@ -313,12 +313,12 @@ class [[nodiscard(
   }
   template <best::comparable<T> U>
   BEST_INLINE_SYNTHETIC constexpr auto operator<=>(best::ok<U> u) const {
-    if (auto v = ok()) return v <=> u.row[best::index<0>];
+    if (auto v = ok()) return v <=> u.args.args[best::index<0>];
     return best::ord::less;
   }
   template <best::comparable<E> U>
   BEST_INLINE_SYNTHETIC constexpr auto operator<=>(best::err<U> u) const {
-    if (auto v = ok()) return v <=> u.rpw[best::index<0>];
+    if (auto v = ok()) return v <=> u.args.args[best::index<0>];
     return best::ord::less;
   }
   BEST_INLINE_SYNTHETIC constexpr auto operator<=>(best::ok<> u) const {

--- a/best/container/result.h
+++ b/best/container/result.h
@@ -44,7 +44,7 @@ namespace best {
 template <typename... Args>
 struct ok {
   constexpr ok(Args... args) : args(BEST_FWD(args)...) {}
-  best::fwd<Args...> args;
+  best::args<Args...> args;
 
   friend void BestFmt(auto& fmt, const ok& ok)
     requires requires { fmt.format(ok.args); }
@@ -53,7 +53,7 @@ struct ok {
     fmt.format(ok.args);
   }
   friend constexpr void BestFmtQuery(auto& query, ok*) {
-    query = query.template of<best::fwd<Args...>>;
+    query = query.template of<best::args<Args...>>;
   }
 };
 template <typename... Args>
@@ -71,7 +71,7 @@ ok(Args&&...) -> ok<Args&&...>;
 template <typename... Args>
 struct err {
   constexpr err(Args... args) : args(BEST_FWD(args)...) {}
-  best::fwd<Args...> args;
+  best::args<Args...> args;
 
   friend void BestFmt(auto& fmt, const err& err)
     requires requires { fmt.format(err.args); }
@@ -80,7 +80,7 @@ struct err {
     fmt.format(err.args);
   }
   friend constexpr void BestFmtQuery(auto& query, err*) {
-    query = query.template of<best::fwd<Args...>>;
+    query = query.template of<best::args<Args...>>;
   }
 };
 template <typename... Args>
@@ -282,11 +282,11 @@ class [[nodiscard(
   }
   template <best::equatable<T> U>
   BEST_INLINE_SYNTHETIC constexpr bool operator==(best::ok<U> u) const {
-    return ok() == u.args.args[best::index<0>];
+    return ok() == u.args.row[best::index<0>];
   }
   template <best::equatable<E> U>
   BEST_INLINE_SYNTHETIC constexpr bool operator==(best::err<U> u) const {
-    return err() == u.args.args[best::index<0>];
+    return err() == u.args.row[best::index<0>];
   }
 
   BEST_INLINE_SYNTHETIC constexpr bool operator==(best::ok<> u) const {

--- a/best/container/row.h
+++ b/best/container/row.h
@@ -275,6 +275,123 @@ class row final
   constexpr auto operator+(best::is_row auto&&) const&&;
   constexpr auto operator+(best::is_row auto&&) &&;
 
+  /// # `row::push()`
+  ///
+  /// Returns a new row with an extra element at the end.
+  ///
+  /// This function has the same overload set as `row::insert()`.
+  // clang-format off
+  constexpr auto push(auto&&) const&;
+  constexpr auto push(auto&&) &;
+  constexpr auto push(auto&&) const&&;
+  constexpr auto push(auto&&) &&;
+  constexpr auto push(best::bind_t, auto&&) const&;
+  constexpr auto push(best::bind_t, auto&&) &;
+  constexpr auto push(best::bind_t, auto&&) const&&;
+  constexpr auto push(best::bind_t, auto&&) &&;
+  template <typename T> constexpr auto push(best::tlist<T>, auto&&...) const&;
+  template <typename T> constexpr auto push(best::tlist<T>, auto&&...) &;
+  template <typename T> constexpr auto push(best::tlist<T>, auto&&...) const&&;
+  template <typename T> constexpr auto push(best::tlist<T>, auto&&...) &&;
+  // clang-format on
+
+  /// # `row::insert()`
+  ///
+  /// Returns a new row with an extra element inserted at index `n`.
+  ///
+  /// Like other mutation functions, there are three overloads. One takes a
+  /// single value, and the resulting new row element type is `auto`-deduced.
+  /// One takes `best::bind`, and the resulting new row element type will be
+  /// a reference. One takes `best::types<T>` and several arguments. The
+  /// resulting value is `T`, and it is constructed in-place. All other
+  /// values are copied/moved as appropriate from this row.
+  // clang-format off
+  template <size_t n> constexpr auto insert(best::index_t<n>, auto&&) const&;
+  template <size_t n> constexpr auto insert(best::index_t<n>, auto&&) &;
+  template <size_t n> constexpr auto insert(best::index_t<n>, auto&&) const&&;
+  template <size_t n> constexpr auto insert(best::index_t<n>, auto&&) &&;
+  template <size_t n> constexpr auto insert(best::index_t<n>, best::bind_t, auto&&) const&;
+  template <size_t n> constexpr auto insert(best::index_t<n>, best::bind_t, auto&&) &;
+  template <size_t n> constexpr auto insert(best::index_t<n>, best::bind_t, auto&&) const&&;
+  template <size_t n> constexpr auto insert(best::index_t<n>, best::bind_t, auto&&) &&;
+  template <size_t n, typename T> constexpr auto insert(best::index_t<n>,best::tlist<T>, auto&&...) const&;
+  template <size_t n, typename T> constexpr auto insert(best::index_t<n>,best::tlist<T>, auto&&...) &;
+  template <size_t n, typename T> constexpr auto insert(best::index_t<n>,best::tlist<T>, auto&&...) const&&;
+  template <size_t n, typename T> constexpr auto insert(best::index_t<n>,best::tlist<T>, auto&&...) &&;
+  // clang-format on
+
+  /// # `row::update()`
+  ///
+  /// Functionally equivalent to `row::insert()`, except it replaces the `n`th
+  /// element instead of inserting into the `n`th slot.
+  // clang-format off
+  template <size_t n> constexpr auto update(best::index_t<n>, auto&&) const&;
+  template <size_t n> constexpr auto update(best::index_t<n>, auto&&) &;
+  template <size_t n> constexpr auto update(best::index_t<n>, auto&&) const&&;
+  template <size_t n> constexpr auto update(best::index_t<n>, auto&&) &&;
+  template <size_t n> constexpr auto update(best::index_t<n>, best::bind_t, auto&&) const&;
+  template <size_t n> constexpr auto update(best::index_t<n>, best::bind_t, auto&&) &;
+  template <size_t n> constexpr auto update(best::index_t<n>, best::bind_t, auto&&) const&&;
+  template <size_t n> constexpr auto update(best::index_t<n>, best::bind_t, auto&&) &&;
+  template <size_t n, typename T> constexpr auto update(best::index_t<n>,best::tlist<T>, auto&&...) const&;
+  template <size_t n, typename T> constexpr auto update(best::index_t<n>,best::tlist<T>, auto&&...) &;
+  template <size_t n, typename T> constexpr auto update(best::index_t<n>,best::tlist<T>, auto&&...) const&&;
+  template <size_t n, typename T> constexpr auto update(best::index_t<n>,best::tlist<T>, auto&&...) &&;
+  // clang-format on
+
+  /// # `row::splice()`
+  ///
+  /// Returns a new row with a specific range replaced by the given row.
+  /// Values are moved/copied out of this row, and the spliced-in row, as
+  /// appropriate.
+  ///
+  /// A separate set of overloads takes an extra `best::types<...>` argument,
+  /// which specifies what the spliced-in types should be independent of the
+  /// argument. This list should have the same size as the input row.
+  template <best::bounds range>
+  constexpr auto splice(best::vlist<range>, best::is_row auto&&) const&;
+  template <best::bounds range>
+  constexpr auto splice(best::vlist<range>, best::is_row auto&&) &;
+  template <best::bounds range>
+  constexpr auto splice(best::vlist<range>, best::is_row auto&&) const&&;
+  template <best::bounds range>
+  constexpr auto splice(best::vlist<range>, best::is_row auto&&) &&;
+
+  template <best::bounds range, typename... Those>
+  constexpr auto splice(best::vlist<range>, best::tlist<Those...>,
+                        best::is_row auto&&) const&;
+  template <best::bounds range, typename... Those>
+  constexpr auto splice(best::vlist<range>, best::tlist<Those...>,
+                        best::is_row auto&&) &;
+  template <best::bounds range, typename... Those>
+  constexpr auto splice(best::vlist<range>, best::tlist<Those...>,
+                        best::is_row auto&&) const&&;
+  template <best::bounds range, typename... Those>
+  constexpr auto splice(best::vlist<range>, best::tlist<Those...>,
+                        best::is_row auto&&) &&;
+
+  /// # `row::remove()`
+  ///
+  /// Returns a new row with the `n`th element removed. All other elements are
+  /// moved/copied out of this row.
+  // clang-format off
+  template <size_t n> constexpr auto remove(best::index_t<n> = {}) const&;
+  template <size_t n> constexpr auto remove(best::index_t<n> = {}) &;
+  template <size_t n> constexpr auto remove(best::index_t<n> = {}) const&&;
+  template <size_t n> constexpr auto remove(best::index_t<n> = {}) &&;
+  // clang-format on
+
+  /// # `row::erase()`
+  ///
+  /// Returns a new row with the given range. All other elements are
+  /// moved/copied out of this row.
+  // clang-format off
+  template <best::bounds range> constexpr auto erase(best::vlist<range> = {}) const&;
+  template <best::bounds range> constexpr auto erase(best::vlist<range> = {}) &;
+  template <best::bounds range> constexpr auto erase(best::vlist<range> = {}) const&&;
+  template <best::bounds range> constexpr auto erase(best::vlist<range> = {}) &&;
+  // clang-format on
+
   /// # `row::apply()`
   ///
   /// Calls `f` with a pack of references of the elements of this tuple.
@@ -696,9 +813,424 @@ template <typename... A>
     requires(!types.is_empty()) {
       return BEST_MOVE(*this).at(index<types.size() - 1>);
     }
+#define BEST_ROW_MUST_USE(func_)                              \
+  [[nodiscard("best::row::" #func_                            \
+              "() does not mutate its argument; instead, it " \
+              "returns a new best::row")]]
 
     template <typename... A>
-    constexpr decltype(auto) row<A...>::apply(auto&& f) const& {
+    BEST_ROW_MUST_USE(push)
+    constexpr auto row<A...>::push(auto&& that) const& {
+  return splice(best::vals<bounds{.start = size()}>,
+                best::types<best::as_auto<decltype(that)>>,
+                best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+BEST_ROW_MUST_USE(push)
+constexpr auto row<A...>::push(auto&& that) & {
+  return splice(best::vals<bounds{.start = size()}>,
+                best::types<best::as_auto<decltype(that)>>,
+                best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+BEST_ROW_MUST_USE(push)
+constexpr auto row<A...>::push(auto&& that) const&& {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = size()}>,
+                                 best::types<best::as_auto<decltype(that)>>,
+                                 best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+BEST_ROW_MUST_USE(push)
+constexpr auto row<A...>::push(auto&& that) && {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = size()}>,
+                                 best::types<best::as_auto<decltype(that)>>,
+                                 best::row(best::bind, BEST_FWD(that)));
+}
+
+template <typename... A>
+BEST_ROW_MUST_USE(push)
+constexpr auto row<A...>::push(best::bind_t, auto&& that) const& {
+  return splice(best::vals<bounds{.start = size()}>,
+                best::types<decltype(that)&&>,
+                best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+BEST_ROW_MUST_USE(push)
+constexpr auto row<A...>::push(best::bind_t, auto&& that) & {
+  return splice(best::vals<bounds{.start = size()}>,
+                best::types<decltype(that)&&>,
+                best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+BEST_ROW_MUST_USE(push)
+constexpr auto row<A...>::push(best::bind_t, auto&& that) const&& {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = size()}>,
+                                 best::types<decltype(that)&&>,
+                                 best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+BEST_ROW_MUST_USE(push)
+constexpr auto row<A...>::push(best::bind_t, auto&& that) && {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = size()}>,
+                                 best::types<decltype(that)&&>,
+                                 best::row(best::bind, BEST_FWD(that)));
+}
+
+template <typename... A>
+template <typename T>
+BEST_ROW_MUST_USE(push)
+constexpr auto row<A...>::push(best::tlist<T>, auto&&... those) const& {
+  return splice(best::vals<bounds{.start = size()}>, best::types<T>,
+                best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+}
+template <typename... A>
+template <typename T>
+BEST_ROW_MUST_USE(push)
+constexpr auto row<A...>::push(best::tlist<T>, auto&&... those) & {
+  return splice(best::vals<bounds{.start = size()}>, best::types<T>,
+                best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+}
+template <typename... A>
+template <typename T>
+BEST_ROW_MUST_USE(push)
+constexpr auto row<A...>::push(best::tlist<T>, auto&&... those) const&& {
+  return BEST_MOVE(*this).splice(
+      best::vals<bounds{.start = size()}>, best::types<T>,
+      best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+}
+template <typename... A>
+template <typename T>
+BEST_ROW_MUST_USE(push)
+constexpr auto row<A...>::push(best::tlist<T>, auto&&... those) && {
+  return BEST_MOVE(*this).splice(
+      best::vals<bounds{.start = size()}>, best::types<T>,
+      best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+}
+
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(insert)
+constexpr auto row<A...>::insert(best::index_t<n>, auto&& that) const& {
+  return splice(best::vals<bounds{.start = n, .count = 0}>,
+                best::types<best::as_auto<decltype(that)>>,
+                best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(insert)
+constexpr auto row<A...>::insert(best::index_t<n>, auto&& that) & {
+  return splice(best::vals<bounds{.start = n, .count = 0}>,
+                best::types<best::as_auto<decltype(that)>>,
+                best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(insert)
+constexpr auto row<A...>::insert(best::index_t<n>, auto&& that) const&& {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 0}>,
+                                 best::types<best::as_auto<decltype(that)>>,
+                                 best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(insert)
+constexpr auto row<A...>::insert(best::index_t<n>, auto&& that) && {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 0}>,
+                                 best::types<best::as_auto<decltype(that)>>,
+                                 best::row(best::bind, BEST_FWD(that)));
+}
+
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(insert)
+constexpr auto row<A...>::insert(best::index_t<n>, best::bind_t,
+                                 auto&& that) const& {
+  return splice(best::vals<bounds{.start = n, .count = 0}>,
+                best::types<decltype(that)&&>,
+                best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(insert)
+constexpr auto row<A...>::insert(best::index_t<n>, best::bind_t,
+                                 auto&& that) & {
+  return splice(best::vals<bounds{.start = n, .count = 0}>,
+                best::types<decltype(that)&&>,
+                best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(insert)
+constexpr auto row<A...>::insert(best::index_t<n>, best::bind_t,
+                                 auto&& that) const&& {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 0}>,
+                                 best::types<decltype(that)&&>,
+                                 best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(insert)
+constexpr auto row<A...>::insert(best::index_t<n>, best::bind_t,
+                                 auto&& that) && {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 0}>,
+                                 best::types<decltype(that)&&>,
+                                 best::row(best::bind, BEST_FWD(that)));
+}
+
+template <typename... A>
+template <size_t n, typename T>
+BEST_ROW_MUST_USE(insert)
+constexpr auto row<A...>::insert(best::index_t<n>, best::tlist<T>,
+                                 auto&&... those) const& {
+  return splice(best::vals<bounds{.start = n, .count = 0}>, best::types<T>,
+                best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+}
+template <typename... A>
+template <size_t n, typename T>
+BEST_ROW_MUST_USE(insert)
+constexpr auto row<A...>::insert(best::index_t<n>, best::tlist<T>,
+                                 auto&&... those) & {
+  return splice(best::vals<bounds{.start = n, .count = 0}>, best::types<T>,
+                best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+}
+template <typename... A>
+template <size_t n, typename T>
+BEST_ROW_MUST_USE(insert)
+constexpr auto row<A...>::insert(best::index_t<n>, best::tlist<T>,
+                                 auto&&... those) const&& {
+  return BEST_MOVE(*this).splice(
+      best::vals<bounds{.start = n, .count = 0}>, best::types<T>,
+      best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+}
+template <typename... A>
+template <size_t n, typename T>
+BEST_ROW_MUST_USE(insert)
+constexpr auto row<A...>::insert(best::index_t<n>, best::tlist<T>,
+                                 auto&&... those) && {
+  return BEST_MOVE(*this).splice(
+      best::vals<bounds{.start = n, .count = 0}>, best::types<T>,
+      best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+}
+
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(update)
+constexpr auto row<A...>::update(best::index_t<n>, auto&& that) const& {
+  return splice(best::vals<bounds{.start = n, .count = 0}>,
+                best::types<best::as_auto<decltype(that)>>,
+                best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(update)
+constexpr auto row<A...>::update(best::index_t<n>, auto&& that) & {
+  return splice(best::vals<bounds{.start = n, .count = 1}>,
+                best::types<best::as_auto<decltype(that)>>,
+                best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(update)
+constexpr auto row<A...>::update(best::index_t<n>, auto&& that) const&& {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 1}>,
+                                 best::types<best::as_auto<decltype(that)>>,
+                                 best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(update)
+constexpr auto row<A...>::update(best::index_t<n>, auto&& that) && {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 1}>,
+                                 best::types<best::as_auto<decltype(that)>>,
+                                 best::row(best::bind, BEST_FWD(that)));
+}
+
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(update)
+constexpr auto row<A...>::update(best::index_t<n>, best::bind_t,
+                                 auto&& that) const& {
+  return splice(best::vals<bounds{.start = n, .count = 1}>,
+                best::types<decltype(that)&&>,
+                best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(update)
+constexpr auto row<A...>::update(best::index_t<n>, best::bind_t,
+                                 auto&& that) & {
+  return splice(best::vals<bounds{.start = n, .count = 1}>,
+                best::types<decltype(that)&&>,
+                best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(update)
+constexpr auto row<A...>::update(best::index_t<n>, best::bind_t,
+                                 auto&& that) const&& {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 1}>,
+                                 best::types<decltype(that)&&>,
+                                 best::row(best::bind, BEST_FWD(that)));
+}
+template <typename... A>
+template <size_t n>
+BEST_ROW_MUST_USE(update)
+constexpr auto row<A...>::update(best::index_t<n>, best::bind_t,
+                                 auto&& that) && {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 1}>,
+                                 best::types<decltype(that)&&>,
+                                 best::row(best::bind, BEST_FWD(that)));
+}
+
+template <typename... A>
+template <size_t n, typename T>
+BEST_ROW_MUST_USE(update)
+constexpr auto row<A...>::update(best::index_t<n>, best::tlist<T>,
+                                 auto&&... those) const& {
+  return splice(best::vals<bounds{.start = n, .count = 1}>, best::types<T>,
+                best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+}
+template <typename... A>
+template <size_t n, typename T>
+BEST_ROW_MUST_USE(update)
+constexpr auto row<A...>::update(best::index_t<n>, best::tlist<T>,
+                                 auto&&... those) & {
+  return splice(best::vals<bounds{.start = n, .count = 1}>, best::types<T>,
+                best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+}
+template <typename... A>
+template <size_t n, typename T>
+BEST_ROW_MUST_USE(update)
+constexpr auto row<A...>::update(best::index_t<n>, best::tlist<T>,
+                                 auto&&... those) const&& {
+  return BEST_MOVE(*this).splice(
+      best::vals<bounds{.start = n, .count = 1}>, best::types<T>,
+      best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+}
+template <typename... A>
+template <size_t n, typename T>
+BEST_ROW_MUST_USE(update)
+constexpr auto row<A...>::update(best::index_t<n>, best::tlist<T>,
+                                 auto&&... those) && {
+  return BEST_MOVE(*this).splice(
+      best::vals<bounds{.start = n, .count = 1}>, best::types<T>,
+      best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+}
+
+template <typename... A>
+template <best::bounds range>
+BEST_ROW_MUST_USE(splice)
+constexpr auto row<A...>::splice(best::vlist<range>,
+                                 best::is_row auto&& those) const& {
+  return row_internal::splice<range, A...>(*this, those.types, BEST_FWD(those));
+}
+template <typename... A>
+template <best::bounds range>
+BEST_ROW_MUST_USE(splice)
+constexpr auto row<A...>::splice(best::vlist<range>,
+                                 best::is_row auto&& those) & {
+  return row_internal::splice<range, A...>(*this, those.types, BEST_FWD(those));
+}
+template <typename... A>
+template <best::bounds range>
+BEST_ROW_MUST_USE(splice)
+constexpr auto row<A...>::splice(best::vlist<range>,
+                                 best::is_row auto&& those) const&& {
+  return row_internal::splice<range, A...>(BEST_MOVE(*this), those.types,
+                                           BEST_FWD(those));
+}
+template <typename... A>
+template <best::bounds range>
+BEST_ROW_MUST_USE(splice)
+constexpr auto row<A...>::splice(best::vlist<range>,
+                                 best::is_row auto&& those) && {
+  return row_internal::splice<range, A...>(BEST_MOVE(*this), those.types,
+                                           BEST_FWD(those));
+}
+
+template <typename... A>
+template <best::bounds range, typename... Those>
+BEST_ROW_MUST_USE(splice)
+constexpr auto row<A...>::splice(best::vlist<range>,
+                                 best::tlist<Those...> those_types,
+                                 best::is_row auto&& those) const& {
+  return row_internal::splice<range, A...>(*this, those_types, BEST_FWD(those));
+}
+template <typename... A>
+template <best::bounds range, typename... Those>
+BEST_ROW_MUST_USE(splice)
+constexpr auto row<A...>::splice(best::vlist<range>,
+                                 best::tlist<Those...> those_types,
+                                 best::is_row auto&& those) & {
+  return row_internal::splice<range, A...>(*this, those_types, BEST_FWD(those));
+}
+template <typename... A>
+template <best::bounds range, typename... Those>
+BEST_ROW_MUST_USE(splice)
+constexpr auto row<A...>::splice(best::vlist<range>,
+                                 best::tlist<Those...> those_types,
+                                 best::is_row auto&& those) const&& {
+  return row_internal::splice<range, A...>(BEST_MOVE(*this), those_types,
+                                           BEST_FWD(those));
+}
+template <typename... A>
+template <best::bounds range, typename... Those>
+BEST_ROW_MUST_USE(splice)
+constexpr auto row<A...>::splice(best::vlist<range>,
+                                 best::tlist<Those...> those_types,
+                                 best::is_row auto&& those) && {
+  return row_internal::splice<range, A...>(BEST_MOVE(*this), those_types,
+                                           BEST_FWD(those));
+}
+
+template <typename... A>
+template <size_t n>
+constexpr auto row<A...>::remove(best::index_t<n>) const& {
+  return splice(best::vals<bounds{.start = n, .count = 1}>, best::row());
+}
+template <typename... A>
+template <size_t n>
+constexpr auto row<A...>::remove(best::index_t<n>) & {
+  return splice(best::vals<bounds{.start = n, .count = 1}>, best::row());
+}
+template <typename... A>
+template <size_t n>
+constexpr auto row<A...>::remove(best::index_t<n>) const&& {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 1}>,
+                                 best::row());
+}
+template <typename... A>
+template <size_t n>
+constexpr auto row<A...>::remove(best::index_t<n>) && {
+  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 1}>,
+                                 best::row());
+}
+
+template <typename... A>
+template <best::bounds range>
+constexpr auto row<A...>::erase(best::vlist<range>) const& {
+  return splice(best::vals<range>, best::row());
+}
+template <typename... A>
+template <best::bounds range>
+constexpr auto row<A...>::erase(best::vlist<range>) & {
+  return splice(best::vals<range>, best::row());
+}
+template <typename... A>
+template <best::bounds range>
+constexpr auto row<A...>::erase(best::vlist<range>) const&& {
+  return BEST_MOVE(*this).splice(best::vals<range>, best::row());
+}
+template <typename... A>
+template <best::bounds range>
+constexpr auto row<A...>::erase(best::vlist<range>) && {
+  return BEST_MOVE(*this).splice(best::vals<range>, best::row());
+}
+
+#undef BEST_TLIST_MUST_USE
+
+template <typename... A>
+constexpr decltype(auto) row<A...>::apply(auto&& f) const& {
   return indices.apply([&]<typename... I>() -> decltype(auto) {
     return best::call(BEST_FWD(f), get(best::index<I::value>)...);
   });

--- a/best/container/row.h
+++ b/best/container/row.h
@@ -465,16 +465,15 @@ class row final
   constexpr decltype(auto) apply(auto&& f) const&&;
   constexpr decltype(auto) apply(auto&& f) &&;
 
-  /// # `row::forward()`
+  /// # `row::as_args()`
   ///
-  /// Constructs a corresponding `best::args()` for this row. The
-  /// elements of the resulting forwarded row will be the result of calling
-  /// `get()`: references, except if an element is of void type, a best::empty
-  /// value instead.
-  constexpr auto forward() const&;
-  constexpr auto forward() &;
-  constexpr auto forward() const&&;
-  constexpr auto forward() &&;
+  /// Constructs a corresponding `best::args()` for this row. The elements of
+  /// the resulting row will be the result of calling `get()`: references,
+  /// except if an element is of void type, a best::empty value instead.
+  constexpr auto as_args() const&;
+  constexpr auto as_args() &;
+  constexpr auto as_args() const&&;
+  constexpr auto as_args() &&;
 
   friend void BestFmt(auto& fmt, const row& row)
     requires requires(best::object<Elems>... els) { (fmt.format(els), ...); }
@@ -531,27 +530,31 @@ row(best::bind_t, Elems&&...) -> row<Elems&&...>;
 
 namespace best {
 template <typename... A>
-constexpr auto row<A...>::forward() const& {
+constexpr auto row<A...>::as_args() const& {
   return apply([](auto&&... args) {
-    return best::args<decltype(args)...>{row<decltype(args)...>(BEST_FWD(args)...)};
+    return best::args<decltype(args)...>{
+        row<decltype(args)...>(BEST_FWD(args)...)};
   });
 }
 template <typename... A>
-constexpr auto row<A...>::forward() & {
+constexpr auto row<A...>::as_args() & {
   return apply([](auto&&... args) {
-    return best::args<decltype(args)...>{row<decltype(args)...>(BEST_FWD(args)...)};
+    return best::args<decltype(args)...>{
+        row<decltype(args)...>(BEST_FWD(args)...)};
   });
 }
 template <typename... A>
-constexpr auto row<A...>::forward() const&& {
+constexpr auto row<A...>::as_args() const&& {
   return BEST_MOVE(*this).apply([](auto&&... args) {
-    return best::args<decltype(args)...>{row<decltype(args)...>(BEST_FWD(args)...)};
+    return best::args<decltype(args)...>{
+        row<decltype(args)...>(BEST_FWD(args)...)};
   });
 }
 template <typename... A>
-constexpr auto row<A...>::forward() && {
+constexpr auto row<A...>::as_args() && {
   return BEST_MOVE(*this).apply([](auto&&... args) {
-    return best::args<decltype(args)...>{row<decltype(args)...>(BEST_FWD(args)...)};
+    return best::args<decltype(args)...>{
+        row<decltype(args)...>(BEST_FWD(args)...)};
   });
 }
 

--- a/best/container/row.h
+++ b/best/container/row.h
@@ -279,7 +279,13 @@ class row final
   ///
   /// Returns a new row with an extra element at the end.
   ///
-  /// This function has the same overload set as `row::insert()`.
+  /// Like other mutation functions, there are three overloads. One takes a
+  /// single value, and the resulting new row element type is `auto`-deduced.
+  /// One takes `best::bind`, and the resulting new row element type will be
+  /// a reference. One takes `best::types<T>`, and resulting value is `T`. To
+  /// construct with multiple arguments, use a `best::row_forward`.
+  ///
+  /// All other values are copied/moved as appropriate from this row.
   // clang-format off
   constexpr auto push(auto&&) const&;
   constexpr auto push(auto&&) &;
@@ -289,35 +295,30 @@ class row final
   constexpr auto push(best::bind_t, auto&&) &;
   constexpr auto push(best::bind_t, auto&&) const&&;
   constexpr auto push(best::bind_t, auto&&) &&;
-  template <typename T> constexpr auto push(best::tlist<T>, auto&&...) const&;
-  template <typename T> constexpr auto push(best::tlist<T>, auto&&...) &;
-  template <typename T> constexpr auto push(best::tlist<T>, auto&&...) const&&;
-  template <typename T> constexpr auto push(best::tlist<T>, auto&&...) &&;
+  template <typename T> constexpr auto push(best::tlist<T>, auto&&) const&;
+  template <typename T> constexpr auto push(best::tlist<T>, auto&&) &;
+  template <typename T> constexpr auto push(best::tlist<T>, auto&&) const&&;
+  template <typename T> constexpr auto push(best::tlist<T>, auto&&) &&;
   // clang-format on
 
   /// # `row::insert()`
   ///
   /// Returns a new row with an extra element inserted at index `n`.
   ///
-  /// Like other mutation functions, there are three overloads. One takes a
-  /// single value, and the resulting new row element type is `auto`-deduced.
-  /// One takes `best::bind`, and the resulting new row element type will be
-  /// a reference. One takes `best::types<T>` and several arguments. The
-  /// resulting value is `T`, and it is constructed in-place. All other
-  /// values are copied/moved as appropriate from this row.
+  /// This function has the same overload set as `row::push()`.
   // clang-format off
-  template <size_t n> constexpr auto insert(best::index_t<n>, auto&&) const&;
-  template <size_t n> constexpr auto insert(best::index_t<n>, auto&&) &;
-  template <size_t n> constexpr auto insert(best::index_t<n>, auto&&) const&&;
-  template <size_t n> constexpr auto insert(best::index_t<n>, auto&&) &&;
-  template <size_t n> constexpr auto insert(best::index_t<n>, best::bind_t, auto&&) const&;
-  template <size_t n> constexpr auto insert(best::index_t<n>, best::bind_t, auto&&) &;
-  template <size_t n> constexpr auto insert(best::index_t<n>, best::bind_t, auto&&) const&&;
-  template <size_t n> constexpr auto insert(best::index_t<n>, best::bind_t, auto&&) &&;
-  template <size_t n, typename T> constexpr auto insert(best::index_t<n>,best::tlist<T>, auto&&...) const&;
-  template <size_t n, typename T> constexpr auto insert(best::index_t<n>,best::tlist<T>, auto&&...) &;
-  template <size_t n, typename T> constexpr auto insert(best::index_t<n>,best::tlist<T>, auto&&...) const&&;
-  template <size_t n, typename T> constexpr auto insert(best::index_t<n>,best::tlist<T>, auto&&...) &&;
+  template <size_t n> constexpr auto insert(auto&&, best::index_t<n> = {}) const&;
+  template <size_t n> constexpr auto insert(auto&&, best::index_t<n> = {}) &;
+  template <size_t n> constexpr auto insert(auto&&, best::index_t<n> = {}) const&&;
+  template <size_t n> constexpr auto insert(auto&&, best::index_t<n> = {}) &&;
+  template <size_t n> constexpr auto insert(best::bind_t, auto&&, best::index_t<n> = {}) const&;
+  template <size_t n> constexpr auto insert(best::bind_t, auto&&, best::index_t<n> = {}) &;
+  template <size_t n> constexpr auto insert(best::bind_t, auto&&, best::index_t<n> = {}) const&&;
+  template <size_t n> constexpr auto insert(best::bind_t, auto&&, best::index_t<n> = {}) &&;
+  template <size_t n, typename T> constexpr auto insert(best::tlist<T>, auto&&, best::index_t<n> = {}) const&;
+  template <size_t n, typename T> constexpr auto insert(best::tlist<T>, auto&&, best::index_t<n> = {}) &;
+  template <size_t n, typename T> constexpr auto insert(best::tlist<T>, auto&&, best::index_t<n> = {}) const&&;
+  template <size_t n, typename T> constexpr auto insert(best::tlist<T>, auto&&, best::index_t<n> = {}) &&;
   // clang-format on
 
   /// # `row::update()`
@@ -325,18 +326,18 @@ class row final
   /// Functionally equivalent to `row::insert()`, except it replaces the `n`th
   /// element instead of inserting into the `n`th slot.
   // clang-format off
-  template <size_t n> constexpr auto update(best::index_t<n>, auto&&) const&;
-  template <size_t n> constexpr auto update(best::index_t<n>, auto&&) &;
-  template <size_t n> constexpr auto update(best::index_t<n>, auto&&) const&&;
-  template <size_t n> constexpr auto update(best::index_t<n>, auto&&) &&;
-  template <size_t n> constexpr auto update(best::index_t<n>, best::bind_t, auto&&) const&;
-  template <size_t n> constexpr auto update(best::index_t<n>, best::bind_t, auto&&) &;
-  template <size_t n> constexpr auto update(best::index_t<n>, best::bind_t, auto&&) const&&;
-  template <size_t n> constexpr auto update(best::index_t<n>, best::bind_t, auto&&) &&;
-  template <size_t n, typename T> constexpr auto update(best::index_t<n>,best::tlist<T>, auto&&...) const&;
-  template <size_t n, typename T> constexpr auto update(best::index_t<n>,best::tlist<T>, auto&&...) &;
-  template <size_t n, typename T> constexpr auto update(best::index_t<n>,best::tlist<T>, auto&&...) const&&;
-  template <size_t n, typename T> constexpr auto update(best::index_t<n>,best::tlist<T>, auto&&...) &&;
+  template <size_t n> constexpr auto update(auto&&, best::index_t<n> = {}) const&;
+  template <size_t n> constexpr auto update(auto&&, best::index_t<n> = {}) &;
+  template <size_t n> constexpr auto update(auto&&, best::index_t<n> = {}) const&&;
+  template <size_t n> constexpr auto update(auto&&, best::index_t<n> = {}) &&;
+  template <size_t n> constexpr auto update(best::bind_t, auto&&, best::index_t<n> = {}) const&;
+  template <size_t n> constexpr auto update(best::bind_t, auto&&, best::index_t<n> = {}) &;
+  template <size_t n> constexpr auto update(best::bind_t, auto&&, best::index_t<n> = {}) const&&;
+  template <size_t n> constexpr auto update(best::bind_t, auto&&, best::index_t<n> = {}) &&;
+  template <size_t n, typename T> constexpr auto update(best::tlist<T>, auto&&, best::index_t<n> = {}) const&;
+  template <size_t n, typename T> constexpr auto update(best::tlist<T>, auto&&, best::index_t<n> = {}) &;
+  template <size_t n, typename T> constexpr auto update(best::tlist<T>, auto&&, best::index_t<n> = {}) const&&;
+  template <size_t n, typename T> constexpr auto update(best::tlist<T>, auto&&, best::index_t<n> = {}) &&;
   // clang-format on
 
   /// # `row::splice()`
@@ -349,26 +350,26 @@ class row final
   /// which specifies what the spliced-in types should be independent of the
   /// argument. This list should have the same size as the input row.
   template <best::bounds range>
-  constexpr auto splice(best::vlist<range>, best::is_row auto&&) const&;
+  constexpr auto splice(best::is_row auto&&, best::vlist<range> = {}) const&;
   template <best::bounds range>
-  constexpr auto splice(best::vlist<range>, best::is_row auto&&) &;
+  constexpr auto splice(best::is_row auto&&, best::vlist<range> = {}) &;
   template <best::bounds range>
-  constexpr auto splice(best::vlist<range>, best::is_row auto&&) const&&;
+  constexpr auto splice(best::is_row auto&&, best::vlist<range> = {}) const&&;
   template <best::bounds range>
-  constexpr auto splice(best::vlist<range>, best::is_row auto&&) &&;
+  constexpr auto splice(best::is_row auto&&, best::vlist<range> = {}) &&;
 
   template <best::bounds range, typename... Those>
-  constexpr auto splice(best::vlist<range>, best::tlist<Those...>,
-                        best::is_row auto&&) const&;
+  constexpr auto splice(best::tlist<Those...>, best::is_row auto&&,
+                        best::vlist<range> = {}) const&;
   template <best::bounds range, typename... Those>
-  constexpr auto splice(best::vlist<range>, best::tlist<Those...>,
-                        best::is_row auto&&) &;
+  constexpr auto splice(best::tlist<Those...>, best::is_row auto&&,
+                        best::vlist<range> = {}) &;
   template <best::bounds range, typename... Those>
-  constexpr auto splice(best::vlist<range>, best::tlist<Those...>,
-                        best::is_row auto&&) const&&;
+  constexpr auto splice(best::tlist<Those...>, best::is_row auto&&,
+                        best::vlist<range> = {}) const&&;
   template <best::bounds range, typename... Those>
-  constexpr auto splice(best::vlist<range>, best::tlist<Those...>,
-                        best::is_row auto&&) &&;
+  constexpr auto splice(best::tlist<Those...>, best::is_row auto&&,
+                        best::vlist<range> = {}) &&;
 
   /// # `row::remove()`
   ///
@@ -470,12 +471,18 @@ template <typename... Args>
 struct row_forward final {
   best::row<Args...> row;
 
+  constexpr explicit row_forward(Args... args) : row(BEST_FWD(args)...) {}
+  constexpr explicit row_forward(best::row<Args...> args)
+      : row(BEST_FWD(args)) {}
+
   template <best::constructible<Args...> T>
   constexpr operator T() && {
     return std::move(row).apply(
         [](auto&&... args) { return T(BEST_FWD(args)...); });
   }
 };
+template <typename... Args>
+row_forward(Args&&...) -> row_forward<Args&&...>;
 }  // namespace best
 
 /* ////////////////////////////////////////////////////////////////////////// *\
@@ -821,329 +828,341 @@ template <typename... A>
     template <typename... A>
     BEST_ROW_MUST_USE(push)
     constexpr auto row<A...>::push(auto&& that) const& {
-  return splice(best::vals<bounds{.start = size()}>,
-                best::types<best::as_auto<decltype(that)>>,
-                best::row(best::bind, BEST_FWD(that)));
+  return splice(best::types<best::as_auto<decltype(that)>>,
+                best::row(best::bind, BEST_FWD(that)),
+                best::vals<bounds{.start = size()}>);
 }
 template <typename... A>
 BEST_ROW_MUST_USE(push)
 constexpr auto row<A...>::push(auto&& that) & {
-  return splice(best::vals<bounds{.start = size()}>,
-                best::types<best::as_auto<decltype(that)>>,
-                best::row(best::bind, BEST_FWD(that)));
+  return splice(best::types<best::as_auto<decltype(that)>>,
+                best::row(best::bind, BEST_FWD(that)),
+                best::vals<bounds{.start = size()}>);
 }
 template <typename... A>
 BEST_ROW_MUST_USE(push)
 constexpr auto row<A...>::push(auto&& that) const&& {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = size()}>,
-                                 best::types<best::as_auto<decltype(that)>>,
-                                 best::row(best::bind, BEST_FWD(that)));
+  return BEST_MOVE(*this).splice(best::types<best::as_auto<decltype(that)>>,
+                                 best::row(best::bind, BEST_FWD(that)),
+                                 best::vals<bounds{.start = size()}>);
 }
 template <typename... A>
 BEST_ROW_MUST_USE(push)
 constexpr auto row<A...>::push(auto&& that) && {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = size()}>,
-                                 best::types<best::as_auto<decltype(that)>>,
-                                 best::row(best::bind, BEST_FWD(that)));
+  return BEST_MOVE(*this).splice(best::types<best::as_auto<decltype(that)>>,
+                                 best::row(best::bind, BEST_FWD(that)),
+                                 best::vals<bounds{.start = size()}>);
 }
 
 template <typename... A>
 BEST_ROW_MUST_USE(push)
 constexpr auto row<A...>::push(best::bind_t, auto&& that) const& {
-  return splice(best::vals<bounds{.start = size()}>,
-                best::types<decltype(that)&&>,
-                best::row(best::bind, BEST_FWD(that)));
+  return splice(best::types<decltype(that)&&>,
+                best::row(best::bind, BEST_FWD(that)),
+                best::vals<bounds{.start = size()}>);
 }
 template <typename... A>
 BEST_ROW_MUST_USE(push)
 constexpr auto row<A...>::push(best::bind_t, auto&& that) & {
-  return splice(best::vals<bounds{.start = size()}>,
-                best::types<decltype(that)&&>,
-                best::row(best::bind, BEST_FWD(that)));
+  return splice(best::types<decltype(that)&&>,
+                best::row(best::bind, BEST_FWD(that)),
+                best::vals<bounds{.start = size()}>);
 }
 template <typename... A>
 BEST_ROW_MUST_USE(push)
 constexpr auto row<A...>::push(best::bind_t, auto&& that) const&& {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = size()}>,
-                                 best::types<decltype(that)&&>,
-                                 best::row(best::bind, BEST_FWD(that)));
+  return BEST_MOVE(*this).splice(best::types<decltype(that)&&>,
+                                 best::row(best::bind, BEST_FWD(that)),
+                                 best::vals<bounds{.start = size()}>);
 }
 template <typename... A>
 BEST_ROW_MUST_USE(push)
 constexpr auto row<A...>::push(best::bind_t, auto&& that) && {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = size()}>,
-                                 best::types<decltype(that)&&>,
-                                 best::row(best::bind, BEST_FWD(that)));
+  return BEST_MOVE(*this).splice(best::types<decltype(that)&&>,
+                                 best::row(best::bind, BEST_FWD(that)),
+                                 best::vals<bounds{.start = size()}>);
 }
 
 template <typename... A>
 template <typename T>
 BEST_ROW_MUST_USE(push)
-constexpr auto row<A...>::push(best::tlist<T>, auto&&... those) const& {
-  return splice(best::vals<bounds{.start = size()}>, best::types<T>,
-                best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+constexpr auto row<A...>::push(best::tlist<T>, auto&& those) const& {
+  return splice(best::types<T>,
+                best::row(best::row(best::bind, BEST_FWD(those)).forward()),
+                best::vals<bounds{.start = size()}>);
 }
 template <typename... A>
 template <typename T>
 BEST_ROW_MUST_USE(push)
-constexpr auto row<A...>::push(best::tlist<T>, auto&&... those) & {
-  return splice(best::vals<bounds{.start = size()}>, best::types<T>,
-                best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+constexpr auto row<A...>::push(best::tlist<T>, auto&& those) & {
+  return splice(best::types<T>,
+                best::row(best::row(best::bind, BEST_FWD(those)).forward()),
+                best::vals<bounds{.start = size()}>);
 }
 template <typename... A>
 template <typename T>
 BEST_ROW_MUST_USE(push)
-constexpr auto row<A...>::push(best::tlist<T>, auto&&... those) const&& {
+constexpr auto row<A...>::push(best::tlist<T>, auto&& those) const&& {
   return BEST_MOVE(*this).splice(
-      best::vals<bounds{.start = size()}>, best::types<T>,
-      best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+      best::types<T>,
+      best::row(best::row(best::bind, BEST_FWD(those)).forward()),
+      best::vals<bounds{.start = size()}>);
 }
 template <typename... A>
 template <typename T>
 BEST_ROW_MUST_USE(push)
-constexpr auto row<A...>::push(best::tlist<T>, auto&&... those) && {
+constexpr auto row<A...>::push(best::tlist<T>, auto&& those) && {
   return BEST_MOVE(*this).splice(
-      best::vals<bounds{.start = size()}>, best::types<T>,
-      best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+      best::types<T>,
+      best::row(best::row(best::bind, BEST_FWD(those)).forward()),
+      best::vals<bounds{.start = size()}>);
 }
 
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(insert)
-constexpr auto row<A...>::insert(best::index_t<n>, auto&& that) const& {
-  return splice(best::vals<bounds{.start = n, .count = 0}>,
-                best::types<best::as_auto<decltype(that)>>,
-                best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::insert(auto&& that, best::index_t<n>) const& {
+  return splice(best::types<best::as_auto<decltype(that)>>,
+                best::row(best::bind, BEST_FWD(that)),
+                best::vals<bounds{.start = n, .count = 0}>);
 }
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(insert)
-constexpr auto row<A...>::insert(best::index_t<n>, auto&& that) & {
-  return splice(best::vals<bounds{.start = n, .count = 0}>,
-                best::types<best::as_auto<decltype(that)>>,
-                best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::insert(auto&& that, best::index_t<n>) & {
+  return splice(best::types<best::as_auto<decltype(that)>>,
+                best::row(best::bind, BEST_FWD(that)),
+                best::vals<bounds{.start = n, .count = 0}>);
 }
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(insert)
-constexpr auto row<A...>::insert(best::index_t<n>, auto&& that) const&& {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 0}>,
-                                 best::types<best::as_auto<decltype(that)>>,
-                                 best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::insert(auto&& that, best::index_t<n>) const&& {
+  return BEST_MOVE(*this).splice(best::types<best::as_auto<decltype(that)>>,
+                                 best::row(best::bind, BEST_FWD(that)),
+                                 best::vals<bounds{.start = n, .count = 0}>);
 }
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(insert)
-constexpr auto row<A...>::insert(best::index_t<n>, auto&& that) && {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 0}>,
-                                 best::types<best::as_auto<decltype(that)>>,
-                                 best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::insert(auto&& that, best::index_t<n>) && {
+  return BEST_MOVE(*this).splice(best::types<best::as_auto<decltype(that)>>,
+                                 best::row(best::bind, BEST_FWD(that)),
+                                 best::vals<bounds{.start = n, .count = 0}>);
 }
 
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(insert)
-constexpr auto row<A...>::insert(best::index_t<n>, best::bind_t,
-                                 auto&& that) const& {
-  return splice(best::vals<bounds{.start = n, .count = 0}>,
-                best::types<decltype(that)&&>,
-                best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::insert(best::bind_t, auto&& that,
+                                 best::index_t<n>) const& {
+  return splice(best::types<decltype(that)&&>,
+                best::row(best::bind, BEST_FWD(that)),
+                best::vals<bounds{.start = n, .count = 0}>);
 }
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(insert)
-constexpr auto row<A...>::insert(best::index_t<n>, best::bind_t,
-                                 auto&& that) & {
-  return splice(best::vals<bounds{.start = n, .count = 0}>,
-                best::types<decltype(that)&&>,
-                best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::insert(best::bind_t, auto&& that,
+                                 best::index_t<n>) & {
+  return splice(best::types<decltype(that)&&>,
+                best::row(best::bind, BEST_FWD(that)),
+                best::vals<bounds{.start = n, .count = 0}>);
 }
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(insert)
-constexpr auto row<A...>::insert(best::index_t<n>, best::bind_t,
-                                 auto&& that) const&& {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 0}>,
-                                 best::types<decltype(that)&&>,
-                                 best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::insert(best::bind_t, auto&& that,
+                                 best::index_t<n>) const&& {
+  return BEST_MOVE(*this).splice(best::types<decltype(that)&&>,
+                                 best::row(best::bind, BEST_FWD(that)),
+                                 best::vals<bounds{.start = n, .count = 0}>);
 }
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(insert)
-constexpr auto row<A...>::insert(best::index_t<n>, best::bind_t,
-                                 auto&& that) && {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 0}>,
-                                 best::types<decltype(that)&&>,
-                                 best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::insert(best::bind_t, auto&& that,
+                                 best::index_t<n>) && {
+  return BEST_MOVE(*this).splice(best::types<decltype(that)&&>,
+                                 best::row(best::bind, BEST_FWD(that)),
+                                 best::vals<bounds{.start = n, .count = 0}>);
 }
 
 template <typename... A>
 template <size_t n, typename T>
 BEST_ROW_MUST_USE(insert)
-constexpr auto row<A...>::insert(best::index_t<n>, best::tlist<T>,
-                                 auto&&... those) const& {
-  return splice(best::vals<bounds{.start = n, .count = 0}>, best::types<T>,
-                best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+constexpr auto row<A...>::insert(best::tlist<T>, auto&& those,
+                                 best::index_t<n>) const& {
+  return splice(best::types<T>,
+                best::row(best::row(best::bind, BEST_FWD(those)).forward()),
+                best::vals<bounds{.start = n, .count = 0}>);
 }
 template <typename... A>
 template <size_t n, typename T>
 BEST_ROW_MUST_USE(insert)
-constexpr auto row<A...>::insert(best::index_t<n>, best::tlist<T>,
-                                 auto&&... those) & {
-  return splice(best::vals<bounds{.start = n, .count = 0}>, best::types<T>,
-                best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+constexpr auto row<A...>::insert(best::tlist<T>, auto&& those,
+                                 best::index_t<n>) & {
+  return splice(best::types<T>,
+                best::row(best::row(best::bind, BEST_FWD(those)).forward()),
+                best::vals<bounds{.start = n, .count = 0}>);
 }
 template <typename... A>
 template <size_t n, typename T>
 BEST_ROW_MUST_USE(insert)
-constexpr auto row<A...>::insert(best::index_t<n>, best::tlist<T>,
-                                 auto&&... those) const&& {
+constexpr auto row<A...>::insert(best::tlist<T>, auto&& those,
+                                 best::index_t<n>) const&& {
   return BEST_MOVE(*this).splice(
-      best::vals<bounds{.start = n, .count = 0}>, best::types<T>,
-      best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+      best::types<T>,
+      best::row(best::row(best::bind, BEST_FWD(those)).forward()),
+      best::vals<bounds{.start = n, .count = 0}>);
 }
 template <typename... A>
 template <size_t n, typename T>
 BEST_ROW_MUST_USE(insert)
-constexpr auto row<A...>::insert(best::index_t<n>, best::tlist<T>,
-                                 auto&&... those) && {
+constexpr auto row<A...>::insert(best::tlist<T>, auto&& those,
+                                 best::index_t<n>) && {
   return BEST_MOVE(*this).splice(
-      best::vals<bounds{.start = n, .count = 0}>, best::types<T>,
-      best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+      best::types<T>,
+      best::row(best::row(best::bind, BEST_FWD(those)).forward()),
+      best::vals<bounds{.start = n, .count = 0}>);
 }
 
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(update)
-constexpr auto row<A...>::update(best::index_t<n>, auto&& that) const& {
-  return splice(best::vals<bounds{.start = n, .count = 0}>,
-                best::types<best::as_auto<decltype(that)>>,
-                best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::update(auto&& that, best::index_t<n>) const& {
+  return splice(best::types<best::as_auto<decltype(that)>>,
+                best::row(best::bind, BEST_FWD(that)),
+                best::vals<bounds{.start = n, .count = 0}>);
 }
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(update)
-constexpr auto row<A...>::update(best::index_t<n>, auto&& that) & {
-  return splice(best::vals<bounds{.start = n, .count = 1}>,
-                best::types<best::as_auto<decltype(that)>>,
-                best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::update(auto&& that, best::index_t<n>) & {
+  return splice(best::types<best::as_auto<decltype(that)>>,
+                best::row(best::bind, BEST_FWD(that)),
+                best::vals<bounds{.start = n, .count = 1}>);
 }
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(update)
-constexpr auto row<A...>::update(best::index_t<n>, auto&& that) const&& {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 1}>,
-                                 best::types<best::as_auto<decltype(that)>>,
-                                 best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::update(auto&& that, best::index_t<n>) const&& {
+  return BEST_MOVE(*this).splice(best::types<best::as_auto<decltype(that)>>,
+                                 best::row(best::bind, BEST_FWD(that)),
+                                 best::vals<bounds{.start = n, .count = 1}>);
 }
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(update)
-constexpr auto row<A...>::update(best::index_t<n>, auto&& that) && {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 1}>,
-                                 best::types<best::as_auto<decltype(that)>>,
-                                 best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::update(auto&& that, best::index_t<n>) && {
+  return BEST_MOVE(*this).splice(best::types<best::as_auto<decltype(that)>>,
+                                 best::row(best::bind, BEST_FWD(that)),
+                                 best::vals<bounds{.start = n, .count = 1}>);
 }
 
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(update)
-constexpr auto row<A...>::update(best::index_t<n>, best::bind_t,
-                                 auto&& that) const& {
-  return splice(best::vals<bounds{.start = n, .count = 1}>,
-                best::types<decltype(that)&&>,
-                best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::update(best::bind_t, auto&& that,
+                                 best::index_t<n>) const& {
+  return splice(best::types<decltype(that)&&>,
+                best::row(best::bind, BEST_FWD(that)),
+                best::vals<bounds{.start = n, .count = 1}>);
 }
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(update)
-constexpr auto row<A...>::update(best::index_t<n>, best::bind_t,
-                                 auto&& that) & {
-  return splice(best::vals<bounds{.start = n, .count = 1}>,
-                best::types<decltype(that)&&>,
-                best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::update(best::bind_t, auto&& that,
+                                 best::index_t<n>) & {
+  return splice(best::types<decltype(that)&&>,
+                best::row(best::bind, BEST_FWD(that)),
+                best::vals<bounds{.start = n, .count = 1}>);
 }
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(update)
-constexpr auto row<A...>::update(best::index_t<n>, best::bind_t,
-                                 auto&& that) const&& {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 1}>,
-                                 best::types<decltype(that)&&>,
-                                 best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::update(best::bind_t, auto&& that,
+                                 best::index_t<n>) const&& {
+  return BEST_MOVE(*this).splice(best::types<decltype(that)&&>,
+                                 best::row(best::bind, BEST_FWD(that)),
+                                 best::vals<bounds{.start = n, .count = 1}>);
 }
 template <typename... A>
 template <size_t n>
 BEST_ROW_MUST_USE(update)
-constexpr auto row<A...>::update(best::index_t<n>, best::bind_t,
-                                 auto&& that) && {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 1}>,
-                                 best::types<decltype(that)&&>,
-                                 best::row(best::bind, BEST_FWD(that)));
+constexpr auto row<A...>::update(best::bind_t, auto&& that,
+                                 best::index_t<n>) && {
+  return BEST_MOVE(*this).splice(best::types<decltype(that)&&>,
+                                 best::row(best::bind, BEST_FWD(that)),
+                                 best::vals<bounds{.start = n, .count = 1}>);
 }
 
 template <typename... A>
 template <size_t n, typename T>
 BEST_ROW_MUST_USE(update)
-constexpr auto row<A...>::update(best::index_t<n>, best::tlist<T>,
-                                 auto&&... those) const& {
-  return splice(best::vals<bounds{.start = n, .count = 1}>, best::types<T>,
-                best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+constexpr auto row<A...>::update(best::tlist<T>, auto&& those,
+                                 best::index_t<n>) const& {
+  return splice(best::types<T>,
+                best::row(best::row(best::bind, BEST_FWD(those)).forward()),
+                best::vals<bounds{.start = n, .count = 1}>);
 }
 template <typename... A>
 template <size_t n, typename T>
 BEST_ROW_MUST_USE(update)
-constexpr auto row<A...>::update(best::index_t<n>, best::tlist<T>,
-                                 auto&&... those) & {
-  return splice(best::vals<bounds{.start = n, .count = 1}>, best::types<T>,
-                best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+constexpr auto row<A...>::update(best::tlist<T>, auto&& those,
+                                 best::index_t<n>) & {
+  return splice(best::types<T>,
+                best::row(best::row(best::bind, BEST_FWD(those)).forward()),
+                best::vals<bounds{.start = n, .count = 1}>);
 }
 template <typename... A>
 template <size_t n, typename T>
 BEST_ROW_MUST_USE(update)
-constexpr auto row<A...>::update(best::index_t<n>, best::tlist<T>,
-                                 auto&&... those) const&& {
+constexpr auto row<A...>::update(best::tlist<T>, auto&& those,
+                                 best::index_t<n>) const&& {
   return BEST_MOVE(*this).splice(
-      best::vals<bounds{.start = n, .count = 1}>, best::types<T>,
-      best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+      best::types<T>,
+      best::row(best::row(best::bind, BEST_FWD(those)).forward()),
+      best::vals<bounds{.start = n, .count = 1}>);
 }
 template <typename... A>
 template <size_t n, typename T>
 BEST_ROW_MUST_USE(update)
-constexpr auto row<A...>::update(best::index_t<n>, best::tlist<T>,
-                                 auto&&... those) && {
+constexpr auto row<A...>::update(best::tlist<T>, auto&& those,
+                                 best::index_t<n>) && {
   return BEST_MOVE(*this).splice(
-      best::vals<bounds{.start = n, .count = 1}>, best::types<T>,
-      best::row(best::row(best::bind, BEST_FWD(those)...).forward()));
+      best::types<T>,
+      best::row(best::row(best::bind, BEST_FWD(those)).forward()),
+      best::vals<bounds{.start = n, .count = 1}>);
 }
 
 template <typename... A>
 template <best::bounds range>
 BEST_ROW_MUST_USE(splice)
-constexpr auto row<A...>::splice(best::vlist<range>,
-                                 best::is_row auto&& those) const& {
+constexpr auto row<A...>::splice(best::is_row auto&& those,
+                                 best::vlist<range>) const& {
   return row_internal::splice<range, A...>(*this, those.types, BEST_FWD(those));
 }
 template <typename... A>
 template <best::bounds range>
 BEST_ROW_MUST_USE(splice)
-constexpr auto row<A...>::splice(best::vlist<range>,
-                                 best::is_row auto&& those) & {
+constexpr auto row<A...>::splice(best::is_row auto&& those,
+                                 best::vlist<range>) & {
   return row_internal::splice<range, A...>(*this, those.types, BEST_FWD(those));
 }
 template <typename... A>
 template <best::bounds range>
 BEST_ROW_MUST_USE(splice)
-constexpr auto row<A...>::splice(best::vlist<range>,
-                                 best::is_row auto&& those) const&& {
+constexpr auto row<A...>::splice(best::is_row auto&& those,
+                                 best::vlist<range>) const&& {
   return row_internal::splice<range, A...>(BEST_MOVE(*this), those.types,
                                            BEST_FWD(those));
 }
 template <typename... A>
 template <best::bounds range>
 BEST_ROW_MUST_USE(splice)
-constexpr auto row<A...>::splice(best::vlist<range>,
-                                 best::is_row auto&& those) && {
+constexpr auto row<A...>::splice(best::is_row auto&& those,
+                                 best::vlist<range>) && {
   return row_internal::splice<range, A...>(BEST_MOVE(*this), those.types,
                                            BEST_FWD(those));
 }
@@ -1151,34 +1170,34 @@ constexpr auto row<A...>::splice(best::vlist<range>,
 template <typename... A>
 template <best::bounds range, typename... Those>
 BEST_ROW_MUST_USE(splice)
-constexpr auto row<A...>::splice(best::vlist<range>,
-                                 best::tlist<Those...> those_types,
-                                 best::is_row auto&& those) const& {
+constexpr auto row<A...>::splice(best::tlist<Those...> those_types,
+                                 best::is_row auto&& those,
+                                 best::vlist<range>) const& {
   return row_internal::splice<range, A...>(*this, those_types, BEST_FWD(those));
 }
 template <typename... A>
 template <best::bounds range, typename... Those>
 BEST_ROW_MUST_USE(splice)
-constexpr auto row<A...>::splice(best::vlist<range>,
-                                 best::tlist<Those...> those_types,
-                                 best::is_row auto&& those) & {
+constexpr auto row<A...>::splice(best::tlist<Those...> those_types,
+                                 best::is_row auto&& those,
+                                 best::vlist<range>) & {
   return row_internal::splice<range, A...>(*this, those_types, BEST_FWD(those));
 }
 template <typename... A>
 template <best::bounds range, typename... Those>
 BEST_ROW_MUST_USE(splice)
-constexpr auto row<A...>::splice(best::vlist<range>,
-                                 best::tlist<Those...> those_types,
-                                 best::is_row auto&& those) const&& {
+constexpr auto row<A...>::splice(best::tlist<Those...> those_types,
+                                 best::is_row auto&& those,
+                                 best::vlist<range>) const&& {
   return row_internal::splice<range, A...>(BEST_MOVE(*this), those_types,
                                            BEST_FWD(those));
 }
 template <typename... A>
 template <best::bounds range, typename... Those>
 BEST_ROW_MUST_USE(splice)
-constexpr auto row<A...>::splice(best::vlist<range>,
-                                 best::tlist<Those...> those_types,
-                                 best::is_row auto&& those) && {
+constexpr auto row<A...>::splice(best::tlist<Those...> those_types,
+                                 best::is_row auto&& those,
+                                 best::vlist<range>) && {
   return row_internal::splice<range, A...>(BEST_MOVE(*this), those_types,
                                            BEST_FWD(those));
 }
@@ -1186,45 +1205,45 @@ constexpr auto row<A...>::splice(best::vlist<range>,
 template <typename... A>
 template <size_t n>
 constexpr auto row<A...>::remove(best::index_t<n>) const& {
-  return splice(best::vals<bounds{.start = n, .count = 1}>, best::row());
+  return splice(best::row(), best::vals<bounds{.start = n, .count = 1}>);
 }
 template <typename... A>
 template <size_t n>
 constexpr auto row<A...>::remove(best::index_t<n>) & {
-  return splice(best::vals<bounds{.start = n, .count = 1}>, best::row());
+  return splice(best::row(), best::vals<bounds{.start = n, .count = 1}>);
 }
 template <typename... A>
 template <size_t n>
 constexpr auto row<A...>::remove(best::index_t<n>) const&& {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 1}>,
-                                 best::row());
+  return BEST_MOVE(*this).splice(best::row(),
+                                 best::vals<bounds{.start = n, .count = 1}>);
 }
 template <typename... A>
 template <size_t n>
 constexpr auto row<A...>::remove(best::index_t<n>) && {
-  return BEST_MOVE(*this).splice(best::vals<bounds{.start = n, .count = 1}>,
-                                 best::row());
+  return BEST_MOVE(*this).splice(best::row(),
+                                 best::vals<bounds{.start = n, .count = 1}>);
 }
 
 template <typename... A>
 template <best::bounds range>
 constexpr auto row<A...>::erase(best::vlist<range>) const& {
-  return splice(best::vals<range>, best::row());
+  return splice(best::row(), best::vals<range>);
 }
 template <typename... A>
 template <best::bounds range>
 constexpr auto row<A...>::erase(best::vlist<range>) & {
-  return splice(best::vals<range>, best::row());
+  return splice(best::row(), best::vals<range>);
 }
 template <typename... A>
 template <best::bounds range>
 constexpr auto row<A...>::erase(best::vlist<range>) const&& {
-  return BEST_MOVE(*this).splice(best::vals<range>, best::row());
+  return BEST_MOVE(*this).splice(best::row(), best::vals<range>);
 }
 template <typename... A>
 template <best::bounds range>
 constexpr auto row<A...>::erase(best::vlist<range>) && {
-  return BEST_MOVE(*this).splice(best::vals<range>, best::row());
+  return BEST_MOVE(*this).splice(best::row(), best::vals<range>);
 }
 
 #undef BEST_TLIST_MUST_USE

--- a/best/container/row.h
+++ b/best/container/row.h
@@ -46,7 +46,7 @@ concept is_row = requires(T t) {
   {
     t.types.apply([]<typename... U>() -> best::row<U...> { std::abort(); })
   } -> best::same<best::as_auto<T>>;
-};
+}; 
 
 /// # `best::row`
 ///
@@ -1306,6 +1306,7 @@ constexpr auto row<A...>::gather(best::vlist<n...>) && {
 
 template <typename... A>
 template <size_t... n>
+BEST_ROW_MUST_USE(scatter)
 constexpr auto row<A...>::scatter(best::is_row auto&& those,
                                   best::vlist<n...>) const& {
   return row_internal::scatter<n...>(*this, those.types, BEST_FWD(those));
@@ -1313,6 +1314,7 @@ constexpr auto row<A...>::scatter(best::is_row auto&& those,
 
 template <typename... A>
 template <size_t... n>
+BEST_ROW_MUST_USE(scatter)
 constexpr auto row<A...>::scatter(best::is_row auto&& those,
                                   best::vlist<n...>) & {
   return row_internal::scatter<n...>(*this, those.types, BEST_FWD(those));
@@ -1320,6 +1322,7 @@ constexpr auto row<A...>::scatter(best::is_row auto&& those,
 
 template <typename... A>
 template <size_t... n>
+BEST_ROW_MUST_USE(scatter)
 constexpr auto row<A...>::scatter(best::is_row auto&& those,
                                   best::vlist<n...>) const&& {
   return row_internal::scatter<n...>(BEST_MOVE(*this), those.types,
@@ -1328,6 +1331,7 @@ constexpr auto row<A...>::scatter(best::is_row auto&& those,
 
 template <typename... A>
 template <size_t... n>
+BEST_ROW_MUST_USE(scatter)
 constexpr auto row<A...>::scatter(best::is_row auto&& those,
                                   best::vlist<n...>) && {
   return row_internal::scatter<n...>(BEST_MOVE(*this), those.types,
@@ -1336,6 +1340,7 @@ constexpr auto row<A...>::scatter(best::is_row auto&& those,
 
 template <typename... A>
 template <size_t... n, typename... Ts>
+BEST_ROW_MUST_USE(scatter)
 constexpr auto row<A...>::scatter(best::tlist<Ts...> those_types,
                                   best::is_row auto&& those,
                                   best::vlist<n...>) const& {
@@ -1344,6 +1349,7 @@ constexpr auto row<A...>::scatter(best::tlist<Ts...> those_types,
 
 template <typename... A>
 template <size_t... n, typename... Ts>
+BEST_ROW_MUST_USE(scatter)
 constexpr auto row<A...>::scatter(best::tlist<Ts...> those_types,
                                   best::is_row auto&& those,
                                   best::vlist<n...>) & {
@@ -1352,6 +1358,7 @@ constexpr auto row<A...>::scatter(best::tlist<Ts...> those_types,
 
 template <typename... A>
 template <size_t... n, typename... Ts>
+BEST_ROW_MUST_USE(scatter)
 constexpr auto row<A...>::scatter(best::tlist<Ts...> those_types,
                                   best::is_row auto&& those,
                                   best::vlist<n...>) const&& {
@@ -1361,6 +1368,7 @@ constexpr auto row<A...>::scatter(best::tlist<Ts...> those_types,
 
 template <typename... A>
 template <size_t... n, typename... Ts>
+BEST_ROW_MUST_USE(scatter)
 constexpr auto row<A...>::scatter(best::tlist<Ts...> those_types,
                                   best::is_row auto&& those,
                                   best::vlist<n...>) && {

--- a/best/container/row_test.cc
+++ b/best/container/row_test.cc
@@ -46,7 +46,7 @@ best::test Fwd = [](auto& t) {
   float x;
   best::row<int, const float&, bool> x0{42, x, true};
 
-  static_assert(best::same<decltype(std::move(x0).forward()),
+  static_assert(best::same<decltype(std::move(x0).as_args()),
                            best::args<int&&, const float&, bool&&>>);
 };
 

--- a/best/container/row_test.cc
+++ b/best/container/row_test.cc
@@ -47,7 +47,7 @@ best::test Fwd = [](auto& t) {
   best::row<int, const float&, bool> x0{42, x, true};
 
   static_assert(best::same<decltype(std::move(x0).forward()),
-                           best::row_forward<int&&, const float&, bool&&>>);
+                           best::fwd<int&&, const float&, bool&&>>);
 };
 
 best::test ToString = [](auto& t) {

--- a/best/container/row_test.cc
+++ b/best/container/row_test.cc
@@ -19,9 +19,12 @@
 
 #include "best/container/row.h"
 
+#include "best/test/fodder.h"
 #include "best/test/test.h"
 
 namespace best::row_test {
+using ::best_fodder::MoveOnly;
+
 static_assert(best::is_empty<best::row<>>);
 
 best::test Nums = [](auto& t) {
@@ -80,11 +83,20 @@ best::test Select = [](auto& t) {
   t.expect_eq(x1.select<Tag>(), best::row(Tagged1(), Tag()));
 };
 
-best::test refs = [](auto& t) {
+best::test Refs = [](auto& t) {
   int x = 0;
   const int y = 2;
   best::row x0(best::bind, x, y);
 
   static_assert(best::same<decltype(x0), best::row<int&, const int&>>);
+};
+
+best::test Join = [](auto& t) {
+  best::row<int, long, int*, int> x0{1, 2, nullptr, 4};
+  t.expect_eq(x0 + x0, best::row(1, 2, nullptr, 4, 1, 2, nullptr, 4));
+
+  best::row x1{MoveOnly()};
+  best::row<MoveOnly> x2 = BEST_MOVE(x1) + best::row();
+  x2 = best::row() + BEST_MOVE(x1);
 };
 }  // namespace best::row_test

--- a/best/container/row_test.cc
+++ b/best/container/row_test.cc
@@ -134,14 +134,31 @@ best::test Splice = [](auto& t) {
       x0.insert<3>(best::types<long*>, nullptr);
   t.expect_eq(x22, best::row{1, 2, nullptr, nullptr, 4});
 
-  best::row<int, int, long, int*, int, int> x3 =
+  best::row<int, long, int*, int*> x2o = x0.update<3>(x0[best::index<2>]);
+  t.expect_eq(x2o, best::row{1, 2, nullptr, nullptr});
+
+  best::row<int, long, int*, int*&> x21o =
+      x0.update<3>(best::bind, x0[best::index<2>]);
+  t.expect_eq(x21o, best::row{1, 2, nullptr, nullptr});
+
+  best::row<int, long, int*, long*> x22o =
+      x0.update<3>(best::types<long*>, nullptr);
+  t.expect_eq(x22o, best::row{1, 2, nullptr, nullptr});
+
+  best::row<int, int, long, int*, int, int> x3o =
       x0.splice<best::bounds{.start = 1, .end = 3}>(x0);
-  t.expect_eq(x3, best::row{1, 1, 2, nullptr, 4, 4});
+  t.expect_eq(x3o, best::row{1, 1, 2, nullptr, 4, 4});
 
   best::row<int, long, long, const int*, unsigned, int> x31 =
       x0.splice<best::bounds{.start = 1, .end = 3}>(
           best::types<long, long, const int*, unsigned>, x0);
   t.expect_eq(x31, best::row{1, 1, 2, nullptr, 4, 4});
+
+  best::row x4{MoveOnly(), 42};
+  BEST_MOVE(x4).push(5);
+  BEST_MOVE(x4).insert<0>(5);
+  BEST_MOVE(x4).splice<bounds{.start = 1}>(best::row{1, 2, 3});
+  x4.update<0>(42);  // No need for move.
 };
 
 best::test Erase = [](auto& t) {
@@ -155,5 +172,27 @@ best::test Erase = [](auto& t) {
 
   best::row<> x3 = x0.erase<best::bounds{}>();
   t.expect_eq(x3, best::row());
+
+  best::row x4{MoveOnly(), 42};
+  BEST_MOVE(x4).remove<1>();
+  BEST_MOVE(x4).erase<bounds{.start = 1}>();
+  x4.remove<0>();  // No need for move.
+};
+
+best::test ScatterGather = [](auto& t) {
+  best::row<int, long, int*, int> x0{1, 2, nullptr, 4};
+
+  best::row<int, long> x1 = x0.gather<3, 1>();
+  t.expect_eq(x1, best::row(4, 2));
+
+  best::row<int, char, char, int> x2 = x0.scatter<2, 1>(best::row{'a', 'b'});
+  t.expect_eq(x2, best::row(1, 'b', 'a', 4));
+  best::row<int, long, char, int> x3 = x0.scatter<2>(best::row{'a', 'b'});
+  t.expect_eq(x3, best::row(1, 2, 'a', 4));
+
+  best::row x4{MoveOnly(), 42};
+  BEST_MOVE(x4).gather<0>();
+  BEST_MOVE(x4).scatter<1>(best::row{false});
+  x4.scatter<0>(best::row{false});
 };
 }  // namespace best::row_test

--- a/best/container/row_test.cc
+++ b/best/container/row_test.cc
@@ -109,4 +109,52 @@ best::test Slice = [](auto& t) {
   best::row x1{MoveOnly(), 42};
   BEST_MOVE(x1).at<bounds{.start = 0, .count = 1}>();
 };
+
+best::test Splice = [](auto& t) {
+  best::row<int, long, int*, int> x0{1, 2, nullptr, 4};
+  best::row<int, long, int*, int, int*> x1 = x0.push(x0[best::index<2>]);
+  t.expect_eq(x1, best::row{1, 2, nullptr, 4, nullptr});
+
+  best::row<int, long, int*, int, int*&> x11 =
+      x0.push(best::bind, x0[best::index<2>]);
+  t.expect_eq(x11, best::row{1, 2, nullptr, 4, nullptr});
+
+  best::row<int, long, int*, int, long*> x12 =
+      x0.push(best::types<long*>, nullptr);
+  t.expect_eq(x12, best::row{1, 2, nullptr, 4, nullptr});
+
+  best::row<int, long, int*, int*, int> x2 =
+      x0.insert(best::index<3>, x0[best::index<2>]);
+  t.expect_eq(x2, best::row{1, 2, nullptr, nullptr, 4});
+
+  best::row<int, long, int*, int*&, int> x21 =
+      x0.insert(best::index<3>, best::bind, x0[best::index<2>]);
+  t.expect_eq(x21, best::row{1, 2, nullptr, nullptr, 4});
+
+  best::row<int, long, int*, long*, int> x22 =
+      x0.insert(best::index<3>, best::types<long*>, nullptr);
+  t.expect_eq(x22, best::row{1, 2, nullptr, nullptr, 4});
+
+  best::row<int, int, long, int*, int, int> x3 =
+      x0.splice(best::vals<best::bounds{.start = 1, .end = 3}>, x0);
+  t.expect_eq(x3, best::row{1, 1, 2, nullptr, 4, 4});
+
+  best::row<int, long, long, const int*, unsigned, int> x31 =
+      x0.splice(best::vals<best::bounds{.start = 1, .end = 3}>,
+                best::types<long, long, const int*, unsigned>, x0);
+  t.expect_eq(x31, best::row{1, 1, 2, nullptr, 4, 4});
+};
+
+best::test Erase = [](auto& t) {
+  best::row<int, long, int*, int> x0{1, 2, nullptr, 4};
+  
+  best::row<int, long, int> x1 = x0.remove<2>();
+  t.expect_eq(x1, best::row(1, 2, 4));
+
+  best::row<int, int> x2 = x0.erase<best::bounds{.start = 1, .end = 3}>();
+  t.expect_eq(x2, best::row(1, 4));
+
+  best::row<> x3 = x0.erase<best::bounds{}>();
+  t.expect_eq(x3, best::row());
+};
 }  // namespace best::row_test

--- a/best/container/row_test.cc
+++ b/best/container/row_test.cc
@@ -123,31 +123,30 @@ best::test Splice = [](auto& t) {
       x0.push(best::types<long*>, nullptr);
   t.expect_eq(x12, best::row{1, 2, nullptr, 4, nullptr});
 
-  best::row<int, long, int*, int*, int> x2 =
-      x0.insert(best::index<3>, x0[best::index<2>]);
+  best::row<int, long, int*, int*, int> x2 = x0.insert<3>(x0[best::index<2>]);
   t.expect_eq(x2, best::row{1, 2, nullptr, nullptr, 4});
 
   best::row<int, long, int*, int*&, int> x21 =
-      x0.insert(best::index<3>, best::bind, x0[best::index<2>]);
+      x0.insert<3>(best::bind, x0[best::index<2>]);
   t.expect_eq(x21, best::row{1, 2, nullptr, nullptr, 4});
 
   best::row<int, long, int*, long*, int> x22 =
-      x0.insert(best::index<3>, best::types<long*>, nullptr);
+      x0.insert<3>(best::types<long*>, nullptr);
   t.expect_eq(x22, best::row{1, 2, nullptr, nullptr, 4});
 
   best::row<int, int, long, int*, int, int> x3 =
-      x0.splice(best::vals<best::bounds{.start = 1, .end = 3}>, x0);
+      x0.splice<best::bounds{.start = 1, .end = 3}>(x0);
   t.expect_eq(x3, best::row{1, 1, 2, nullptr, 4, 4});
 
   best::row<int, long, long, const int*, unsigned, int> x31 =
-      x0.splice(best::vals<best::bounds{.start = 1, .end = 3}>,
-                best::types<long, long, const int*, unsigned>, x0);
+      x0.splice<best::bounds{.start = 1, .end = 3}>(
+          best::types<long, long, const int*, unsigned>, x0);
   t.expect_eq(x31, best::row{1, 1, 2, nullptr, 4, 4});
 };
 
 best::test Erase = [](auto& t) {
   best::row<int, long, int*, int> x0{1, 2, nullptr, 4};
-  
+
   best::row<int, long, int> x1 = x0.remove<2>();
   t.expect_eq(x1, best::row(1, 2, 4));
 

--- a/best/container/row_test.cc
+++ b/best/container/row_test.cc
@@ -47,7 +47,7 @@ best::test Fwd = [](auto& t) {
   best::row<int, const float&, bool> x0{42, x, true};
 
   static_assert(best::same<decltype(std::move(x0).forward()),
-                           best::fwd<int&&, const float&, bool&&>>);
+                           best::args<int&&, const float&, bool&&>>);
 };
 
 best::test ToString = [](auto& t) {

--- a/best/container/row_test.cc
+++ b/best/container/row_test.cc
@@ -99,4 +99,14 @@ best::test Join = [](auto& t) {
   best::row<MoveOnly> x2 = BEST_MOVE(x1) + best::row();
   x2 = best::row() + BEST_MOVE(x1);
 };
+
+best::test Slice = [](auto& t) {
+  best::row<int, long, int*, int> x0{1, 2, nullptr, 4};
+  t.expect_eq(x0.at<bounds{.count = 2}>(), best::row{1, 2});
+  t.expect_eq(x0.at<bounds{.start = 2}>(), best::row{nullptr, 4});
+  t.expect_eq(x0.at<bounds{.start = 2, .count = 0}>(), best::row{});
+
+  best::row x1{MoveOnly(), 42};
+  BEST_MOVE(x1).at<bounds{.start = 0, .count = 1}>();
+};
 }  // namespace best::row_test

--- a/best/container/span.h
+++ b/best/container/span.h
@@ -31,7 +31,6 @@
 #include "best/math/overflow.h"
 #include "best/memory/bytes.h"
 #include "best/meta/init.h"
-#include "best/meta/tags.h"
 #include "best/meta/tlist.h"
 
 //! Data spans.

--- a/best/meta/init_test.cc
+++ b/best/meta/init_test.cc
@@ -301,22 +301,20 @@ static_assert(!best::moveable<Stuck, trivially>);
 
 static_assert(best::relocatable<best_fodder::Relocatable, trivially>);
 
-// best::row_forward smoke test.
-static_assert(best::constructible<int, best::row_forward<>>);
-static_assert(best::constructible<int, best::row_forward<int>>);
-static_assert(best::constructible<int, best::row_forward<long>>);
+// best::fwd smoke test.
+static_assert(best::constructible<int, best::fwd<>>);
+static_assert(best::constructible<int, best::fwd<int>>);
+static_assert(best::constructible<int, best::fwd<long>>);
 
-static_assert(best::constructible<int, trivially, best::row_forward<>>);
-static_assert(best::constructible<int, trivially, best::row_forward<int>>);
-static_assert(best::constructible<int, trivially, best::row_forward<long>>);
+static_assert(best::constructible<int, trivially, best::fwd<>>);
+static_assert(best::constructible<int, trivially, best::fwd<int>>);
+static_assert(best::constructible<int, trivially, best::fwd<long>>);
 
-static_assert(best::constructible<NonTrivialPod, best::row_forward<int, int>>);
+static_assert(best::constructible<NonTrivialPod, best::fwd<int, int>>);
+static_assert(best::constructible<NonTrivialPod, best::fwd<const int&, int>>);
+static_assert(best::constructible<NonTrivialPod, best::fwd<NonTrivialPod>>);
 static_assert(
-    best::constructible<NonTrivialPod, best::row_forward<const int&, int>>);
-static_assert(
-    best::constructible<NonTrivialPod, best::row_forward<NonTrivialPod>>);
-static_assert(
-    best::constructible<NonTrivialPod, best::row_forward<const NonTrivialPod>>);
+    best::constructible<NonTrivialPod, best::fwd<const NonTrivialPod>>);
 
 }  // namespace best::init_test
 

--- a/best/meta/init_test.cc
+++ b/best/meta/init_test.cc
@@ -301,20 +301,20 @@ static_assert(!best::moveable<Stuck, trivially>);
 
 static_assert(best::relocatable<best_fodder::Relocatable, trivially>);
 
-// best::fwd smoke test.
-static_assert(best::constructible<int, best::fwd<>>);
-static_assert(best::constructible<int, best::fwd<int>>);
-static_assert(best::constructible<int, best::fwd<long>>);
+// best::args smoke test.
+static_assert(best::constructible<int, best::args<>>);
+static_assert(best::constructible<int, best::args<int>>);
+static_assert(best::constructible<int, best::args<long>>);
 
-static_assert(best::constructible<int, trivially, best::fwd<>>);
-static_assert(best::constructible<int, trivially, best::fwd<int>>);
-static_assert(best::constructible<int, trivially, best::fwd<long>>);
+static_assert(best::constructible<int, trivially, best::args<>>);
+static_assert(best::constructible<int, trivially, best::args<int>>);
+static_assert(best::constructible<int, trivially, best::args<long>>);
 
-static_assert(best::constructible<NonTrivialPod, best::fwd<int, int>>);
-static_assert(best::constructible<NonTrivialPod, best::fwd<const int&, int>>);
-static_assert(best::constructible<NonTrivialPod, best::fwd<NonTrivialPod>>);
+static_assert(best::constructible<NonTrivialPod, best::args<int, int>>);
+static_assert(best::constructible<NonTrivialPod, best::args<const int&, int>>);
+static_assert(best::constructible<NonTrivialPod, best::args<NonTrivialPod>>);
 static_assert(
-    best::constructible<NonTrivialPod, best::fwd<const NonTrivialPod>>);
+    best::constructible<NonTrivialPod, best::args<const NonTrivialPod>>);
 
 }  // namespace best::init_test
 

--- a/best/meta/internal/init.h
+++ b/best/meta/internal/init.h
@@ -131,19 +131,19 @@ void ctor(tag<T>, tag<trivially>, tag<U>);
 // -------------------------------------------------------------------------- //
 
 template <typename T, typename... Args>
-void ctor(tag<T>, tag<best::fwd<Args...>>)
+void ctor(tag<T>, tag<best::args<Args...>>)
   requires requires { ctor(tag<T>{}, tag<Args>{}...); };
 
 template <typename T, typename... Args>
-void ctor(tag<T>, tag<trivially>, tag<best::fwd<Args...>>)
+void ctor(tag<T>, tag<trivially>, tag<best::args<Args...>>)
   requires requires { ctor(tag<T>{}, tag<trivially>{}, tag<Args>{}...); };
 
 template <typename T, typename... Args>
-void ctor(tag<T>, tag<best::fwd<Args...>&&>)
+void ctor(tag<T>, tag<best::args<Args...>&&>)
   requires requires { ctor(tag<T>{}, tag<Args>{}...); };
 
 template <typename T, typename... Args>
-void ctor(tag<T>, tag<trivially>, tag<best::fwd<Args...>&&>)
+void ctor(tag<T>, tag<trivially>, tag<best::args<Args...>&&>)
   requires requires { ctor(tag<T>{}, tag<trivially>{}, tag<Args>{}...); };
 
 // ========================================================================== //
@@ -250,19 +250,19 @@ void assign(tag<T>, tag<trivially>);
 // -------------------------------------------------------------------------- //
 
 template <typename T, typename... Args>
-void assign(tag<T>, tag<best::fwd<Args...>>)
+void assign(tag<T>, tag<best::args<Args...>>)
   requires requires { assign(tag<T>{}, tag<Args>{}...); };
 
 template <typename T, typename... Args>
-void assign(tag<T>, tag<trivially>, tag<best::fwd<Args...>>)
+void assign(tag<T>, tag<trivially>, tag<best::args<Args...>>)
   requires requires { assign(tag<T>{}, tag<trivially>{}, tag<Args>{}...); };
 
 template <typename T, typename... Args>
-void assign(tag<T>, tag<best::fwd<Args...>&&>)
+void assign(tag<T>, tag<best::args<Args...>&&>)
   requires requires { assign(tag<T>{}, tag<Args>{}...); };
 
 template <typename T, typename... Args>
-void assign(tag<T>, tag<trivially>, tag<best::fwd<Args...>&&>)
+void assign(tag<T>, tag<trivially>, tag<best::args<Args...>&&>)
   requires requires { assign(tag<T>{}, tag<trivially>{}, tag<Args>{}...); };
 
 // ========================================================================== //

--- a/best/meta/internal/init.h
+++ b/best/meta/internal/init.h
@@ -131,19 +131,19 @@ void ctor(tag<T>, tag<trivially>, tag<U>);
 // -------------------------------------------------------------------------- //
 
 template <typename T, typename... Args>
-void ctor(tag<T>, tag<best::row_forward<Args...>>)
+void ctor(tag<T>, tag<best::fwd<Args...>>)
   requires requires { ctor(tag<T>{}, tag<Args>{}...); };
 
 template <typename T, typename... Args>
-void ctor(tag<T>, tag<trivially>, tag<best::row_forward<Args...>>)
+void ctor(tag<T>, tag<trivially>, tag<best::fwd<Args...>>)
   requires requires { ctor(tag<T>{}, tag<trivially>{}, tag<Args>{}...); };
 
 template <typename T, typename... Args>
-void ctor(tag<T>, tag<best::row_forward<Args...>&&>)
+void ctor(tag<T>, tag<best::fwd<Args...>&&>)
   requires requires { ctor(tag<T>{}, tag<Args>{}...); };
 
 template <typename T, typename... Args>
-void ctor(tag<T>, tag<trivially>, tag<best::row_forward<Args...>&&>)
+void ctor(tag<T>, tag<trivially>, tag<best::fwd<Args...>&&>)
   requires requires { ctor(tag<T>{}, tag<trivially>{}, tag<Args>{}...); };
 
 // ========================================================================== //
@@ -250,19 +250,19 @@ void assign(tag<T>, tag<trivially>);
 // -------------------------------------------------------------------------- //
 
 template <typename T, typename... Args>
-void assign(tag<T>, tag<best::row_forward<Args...>>)
+void assign(tag<T>, tag<best::fwd<Args...>>)
   requires requires { assign(tag<T>{}, tag<Args>{}...); };
 
 template <typename T, typename... Args>
-void assign(tag<T>, tag<trivially>, tag<best::row_forward<Args...>>)
+void assign(tag<T>, tag<trivially>, tag<best::fwd<Args...>>)
   requires requires { assign(tag<T>{}, tag<trivially>{}, tag<Args>{}...); };
 
 template <typename T, typename... Args>
-void assign(tag<T>, tag<best::row_forward<Args...>&&>)
+void assign(tag<T>, tag<best::fwd<Args...>&&>)
   requires requires { assign(tag<T>{}, tag<Args>{}...); };
 
 template <typename T, typename... Args>
-void assign(tag<T>, tag<trivially>, tag<best::row_forward<Args...>&&>)
+void assign(tag<T>, tag<trivially>, tag<best::fwd<Args...>&&>)
   requires requires { assign(tag<T>{}, tag<trivially>{}, tag<Args>{}...); };
 
 // ========================================================================== //

--- a/best/meta/internal/tlist.h
+++ b/best/meta/internal/tlist.h
@@ -200,7 +200,7 @@ using scatter =
 // for each element of the `n`th list. The odd elements are then `{0, 1, 2, 0,
 // 1, 2, 0, 1, 2}`: for each list `l`, the sequence `{.count = l.size() - 1}`.
 template <size_t total, typename... Packs>
-constexpr auto join_lut() {
+constexpr inline auto join_lut = [] {
   std::array<size_t, total * 2> lut;
 
   size_t running_total = 0;
@@ -215,10 +215,11 @@ constexpr auto join_lut() {
   };
   (fill(Packs::size()), ...);
   return lut;
-}
+}();
+
 template <typename... Packs, size_t... i>
 auto join_impl(std::index_sequence<i...>, Packs...) {
-  constexpr auto lut = join_lut<sizeof...(i), Packs...>();
+  constexpr auto lut = join_lut<sizeof...(i), Packs...>;
   return tlist<typename fast_nth<lut[i * 2], Packs...>  //
                ::template type<lut[i * 2 + 1]>...>{};
 }

--- a/best/meta/internal/tlist.h
+++ b/best/meta/internal/tlist.h
@@ -22,81 +22,209 @@
 
 #include <stddef.h>
 
+#include <array>
 #include <type_traits>
 #include <utility>
 
 #include "best/base/fwd.h"
 #include "best/base/port.h"
 #include "best/container/bounds.h"
-
-#if !__has_builtin(__type_pack_element)
-#include <tuple>
-#endif
+#include "best/func/call.h"
 
 //! Type traits for working with parameter packs.
+
+// This is wrapped up in a define like this so test can override it to make sure
+// we can turn it off.
+#ifndef BEST_TLIST_USE_CLANG_MAGIC_
+#ifdef __clang__
+#define BEST_TLIST_USE_CLANG_MAGIC_ 1
+#else
+#define BEST_TLIST_USE_CLANG_MAGIC_ 0
+#endif
+#endif  // BEST_TLIST_USE_CLANG_MAGIC_
 
 namespace best::tlist_internal {
 struct secret;
 struct strict {};
 
+template <typename... T>
+void is_tlist(tlist<T...>);
+
 template <typename T>
-struct curry_same {
-  template <typename U>
-  struct trait : std::is_same<T, U> {};
+concept not_strict = !std::is_same_v<T, strict>;
+
+template <size_t>
+struct discard {
+  discard(auto...) {}
 };
 
-template <size_t n, typename Default, typename... Pack>
-auto nth_impl()
-  requires(!std::is_same_v<Default, strict> || n < sizeof...(Pack))
-{
-  if constexpr (n < sizeof...(Pack)) {
-#if BEST_HAS_BUILTIN(__type_pack_element)
-    return std::type_identity<__type_pack_element<n, Pack...>>{};
+// Low-level implementation of "index me a list". This is very similar to the
+// implementation given below for make_slicer(), but it dodges a GCC bug around
+// variadic constrained template parameters.
+template <size_t... i>
+auto make_indexer(std::index_sequence<i...>) {
+  return [](discard<i>... prefix, auto infix, auto... suffix) { return infix; };
+}
+
+template <size_t i, typename... Ts>
+using fast_nth =
+#if BEST_TLIST_USE_CLANG_MAGIC_ && BEST_HAS_BUILTIN(__type_pack_element)
+    __type_pack_element<i, Ts...>;
 #else
-    return std::tuple_type_t<i, std::tuple<std::type_identity<Ts>...>>{};
+    typename decltype(typename make_indexer(std::make_index_sequence<i_>{})(
+        best::id<Ts>{}...))::type;
 #endif
-  } else {
-    return std::type_identity<Default>{};
-  }
-}
 
-template <size_t n, typename Default, typename... Pack>
-using nth = decltype(nth_impl<n, Default, Pack...>())::type;
-
-template <size_t start, size_t... count, typename... Pack>
-tlist<
-#if BEST_HAS_BUILTIN(__type_pack_element)
-    __type_pack_element<start + count, Pack...>
+template <size_t n, typename Default, typename... Ts>
+  requires(n < sizeof...(Ts))
+auto nth_impl(tlist<Ts...>) {
+#if BEST_TLIST_USE_CLANG_MAGIC_ && BEST_HAS_BUILTIN(__type_pack_element)
+  return best::id<__type_pack_element<n, Ts...>>{};
 #else
-    std::tuple_type_t<start + count, std::tuple<Ts...>>
+  return make_indexer(std::make_index_sequence<n>{})(best::id<Ts>{}...);
 #endif
-    ...>
-    type_pack_slice(std::index_sequence<count...>, tlist<Pack...>);
-
-template <best::bounds bounds, typename Default, typename Tag,
-          auto count = bounds.try_compute_count(Tag::size())>
-auto slice_impl()
-  requires(!std::is_same_v<Default, strict> || count.has_value())
-{
-  if constexpr (!count) {
-    return std::type_identity<Default>{};
-  } else {
-    return type_pack_slice<bounds.start>(std::make_index_sequence<*count>(),
-                                         Tag{});
-  }
 }
 
-template <best::bounds bounds, typename Default, typename Tag>
-using slice = decltype(tlist_internal::slice_impl<bounds, Default, Tag>());
+template <size_t n, not_strict Default, typename... Ts>
+  requires(n >= sizeof...(Ts))
+auto nth_impl(tlist<Ts...>) {
+  return best::id<Default>{};
+}
 
-template <typename... Buffer>
-constexpr tlist<Buffer...> concat() {
-  return {};
+template <size_t n, typename Default, typename Pack>
+using nth = decltype(nth_impl<n, Default>(best::lie<Pack>))::type;
+
+template <typename, size_t>
+concept splat = true;
+
+// Low-level implementation of "slice me a tlist". This works by constructing
+// a lambda that takes exactly sizeof...(i) + sizeof...(j) + sizeof...(k)
+// template parameters and returning it. To create that, we take the packs of
+// integers constructed using make_index_sequence, and splats them into
+// a template parameter list using constrained-template-parameters, which allows
+// use to use `...` in the template-parameter-list without creating an
+// arbitrary-length pack argument. It has to return a lambda, because we want to
+// "bake" i, j, and k into the lambda's type, so that they cannot be deduced
+// when we actually call it.
+template <size_t... i, size_t... j, size_t... k>
+auto make_slicer(std::index_sequence<i...>, std::index_sequence<j...>,
+                 std::index_sequence<k...>) {
+  return []<splat<i>... prefix, splat<j>... infix, splat<k>... suffix>(
+             id<prefix>..., id<infix>..., id<suffix>...) {
+    return best::id<tlist<infix...>>{};
+  };
 }
-template <typename... Buffer, int&..., typename... Those>
-constexpr auto concat(tlist<Those...>, auto... rest) {
-  return concat<Buffer..., Those...>(rest...);
+
+template <size_t start, auto count, typename Default, typename... Ts>
+  requires(count.has_value())
+auto slice_impl(tlist<Ts...>) {
+  return make_slicer(
+      std::make_index_sequence<start>{}, std::make_index_sequence<*count>{},
+      std::make_index_sequence<sizeof...(Ts) - (start + *count)>{})(
+      best::id<Ts>{}...);
 }
+template <size_t start, auto count, not_strict Default, typename... Ts>
+  requires(!count.has_value())
+best::id<Default> slice_impl(tlist<Ts...>);
+
+template <best::bounds b, typename Default, typename Pack>
+using slice =
+    decltype(slice_impl<b.start, b.try_compute_count(Pack::size()), Default>(
+        best::lie<Pack>))::type;
+
+// Inside-out version of make_slicer.
+template <typename... Ts, size_t... i, size_t... j, size_t... k>
+auto make_splicer(std::index_sequence<i...>, std::index_sequence<j...>,
+                  std::index_sequence<k...>) {
+  return []<splat<i>... prefix, splat<j>... infix, splat<k>... suffix>(
+             id<prefix>..., id<infix>..., id<suffix>...) {
+    return best::id<tlist<prefix..., Ts..., suffix...>>{};
+  };
+}
+
+template <size_t start, auto count, typename Default, typename... Ts,
+          typename... Us>
+  requires(count.has_value())
+auto splice_impl(tlist<Ts...>, tlist<Us...>) {
+  return make_splicer<Us...>(
+      std::make_index_sequence<start>{}, std::make_index_sequence<*count>{},
+      std::make_index_sequence<sizeof...(Ts) - (start + *count)>{})(
+      best::id<Ts>{}...);
+}
+template <size_t start, auto count, not_strict Default, typename... Ts,
+          typename... Us>
+  requires(!count.has_value())
+best::id<Default> splice_impl(tlist<Ts...>, tlist<Us...>);
+
+template <best::bounds b, typename Default, typename Pack, typename Insert>
+using splice =
+    decltype(splice_impl<b.start, b.try_compute_count(Pack::size()), Default>(
+        best::lie<Pack>, best::lie<Insert>))::type;
+
+template <typename Default, size_t... i, typename... Ts>
+  requires((i < sizeof...(Ts)) && ...)  // Fast path for no out-of-bounds.
+auto gather_impl(tlist<Ts...>) {
+  return best::tlist<fast_nth<i, Ts...>...>{};
+}
+template <not_strict Default, size_t... i, typename... Ts>
+  requires((i >= sizeof...(Ts)) || ...)
+auto gather_impl(tlist<Ts...>) {
+  return best::tlist<nth<i, Default, tlist<Ts...>>...>{};
+}
+
+template <typename Default, typename Pack, size_t... i>
+using gather = decltype(gather_impl<Default, i...>(best::lie<Pack>));
+
+template <size_t... i, size_t... j, typename... Ts,
+          typename... Us>
+  requires((i < sizeof...(Ts)) && ...)  // Fast path for no out-of-bounds.
+auto scatter_impl(std::index_sequence<j...>, tlist<Ts...>, tlist<Us...>) {
+  constexpr auto lut = [] {
+    std::array<size_t, sizeof...(Ts)> lut{(j - j)...};
+    size_t n = 1;
+    ((i < lut.size() ? lut[i] = n++ : 0), ...);
+    return lut;
+  }();
+
+  return best::tlist<fast_nth<lut[j], Ts, Us...>...>{};
+}
+
+template <typename Pack, typename Those, size_t... i>
+using scatter =
+    decltype(scatter_impl<i...>(std::make_index_sequence<Pack::size()>{},
+                                best::lie<Pack>, best::lie<Those>));
+
+// This generates a lookup table for computing a join.
+//
+// The even elements of the table are `{0, 0, 0, 1, 1, 1, 2, 2, 2}`, one `n`
+// for each element of the `n`th list. The odd elements are then `{0, 1, 2, 0,
+// 1, 2, 0, 1, 2}`: for each list `l`, the sequence `{.count = l.size() - 1}`.
+template <size_t total, typename... Packs>
+constexpr auto join_lut() {
+  std::array<size_t, total * 2> lut;
+
+  size_t running_total = 0;
+  size_t list = 0;
+  auto fill = [&](size_t n) {
+    for (size_t i = 0; i < n; ++i) {
+      lut[running_total * 2] = list;
+      lut[running_total * 2 + 1] = i;
+      ++running_total;
+    }
+    ++list;
+  };
+  (fill(Packs::size()), ...);
+  return lut;
+}
+template <typename... Packs, size_t... i>
+auto join_impl(std::index_sequence<i...>, Packs...) {
+  constexpr auto lut = join_lut<sizeof...(i), Packs...>();
+  return tlist<typename fast_nth<lut[i * 2], Packs...>  //
+               ::template type<lut[i * 2 + 1]>...>{};
+}
+template <typename... Packs>
+using join = decltype(join_impl(
+    std::make_index_sequence<(0 + ... + Packs::size())>{}, Packs{}...));
 
 template <typename T>
 struct entry {};
@@ -119,6 +247,23 @@ struct set final : std::true_type, entry<Ts>... {
 
 template <typename... Ts>
 concept uniq = (set<>{} + ... + entry<Ts>{}).value;
+
+// Concepts for checking if a function is callable with a particular set of
+// type or value arguments.
+template <typename F, typename... Elems>
+concept t_callable = (... && best::callable<F, void(), Elems>);
+
+template <typename F, typename... Elems>
+concept v_callable = sizeof...(Elems) > 0 &&
+                     (... && requires(F f) { best::call(f, Elems::value); });
+
+template <typename F, typename... Elems>
+concept ts_callable = best::callable<F, void(), Elems...>;
+
+template <typename F, typename... Elems>
+concept vs_callable =
+    sizeof...(Elems) > 0 && requires(F f) { best::call(f, Elems::value...); };
+
 }  // namespace best::tlist_internal
 
 #endif  // BEST_META_INTERNAL_TLIST_H_

--- a/best/meta/tags.h
+++ b/best/meta/tags.h
@@ -51,16 +51,6 @@ inline constexpr struct in_place_t {
 inline constexpr struct bind_t {
 } bind;
 
-/// An alias for std::in_place_index.
-///
-/// Use this to tag things that want to take a size_t.
-template <size_t n>
-struct index_t {
-  static constexpr size_t value = n;
-};
-template <size_t n>
-inline constexpr index_t<n> index;
-
 /// A tag for uninitialized values.
 ///
 /// Use this to define a non-default constructor that produces some kind of

--- a/best/meta/tlist.h
+++ b/best/meta/tlist.h
@@ -216,8 +216,7 @@ class tlist final {
 
   /// # `tlist::join()`, `tlist::operator+`
   ///
-  /// Concatenates several tlists with this one. If an argument to this type is
-  /// not a tlist, it is treated as a one-element tlist.
+  /// Concatenates several tlists with this one.
   ///
   /// This is also made available via `operator+`, but beware: using a fold with
   /// `operator+` here is quadratic; you should generally prefer `join()` for
@@ -433,6 +432,14 @@ class tlist final {
   static constexpr decltype(auto) apply(
       tlist_internal::vs_callable<Elems...> auto cb) {
     return best::call(cb, Elems::value...);
+  };
+  template <template <typename...> typename Trait>
+  static constexpr Trait<Elems...> apply() {
+    return {};
+  }
+  template <template <auto...> typename Trait, typename delay = void>
+  static constexpr Trait<best::dependent<Elems, delay>::value...> apply() {
+    return {};
   };
 
   /// # `tlist::reduce()`

--- a/best/meta/tlist.h
+++ b/best/meta/tlist.h
@@ -89,6 +89,21 @@ inline constexpr best::tlist<Elems...> types;
 template <auto... elems>
 inline constexpr best::vlist<elems...> vals;
 
+/// # `best::index_t<n>`, `best::indices_t<n...>`
+///
+/// A aliases of `vals`/`vlist` for constraining it to `size_t` elements.
+template <size_t n>
+using index_t = val<n>;
+template <size_t... n>
+using indices_t = vlist<n...>;
+
+/// # `best::index<n>`
+///
+/// Helper for constructing `best::index_t`. Note that `best::val<0>` is not
+/// `best::index_t<0>`, because the former is `best::val<int(0)>`.
+template <size_t n>
+inline constexpr index_t<n> index;
+
 /// # `best::indices<...>`
 ///
 /// Constructs a `vlist` containing the elements from `0` to `n`, exclusive.
@@ -210,12 +225,19 @@ class tlist final {
   static constexpr auto join(best::is_tlist auto... those);
   auto operator+(best::is_tlist auto that) { return join(that); }
 
+#define BEST_TLIST_MUST_USE(func_)                            \
+  [[nodiscard("best::tlist::" #func_                          \
+              "() does not mutate its argument; instead, it " \
+              "returns a new best::tlist")]]
+
   /// # `tlist::push()`
   ///
   /// Inserts a new value at the end of the list.
   template <typename T>
+  BEST_TLIST_MUST_USE(push)
   static constexpr auto push();
   template <auto v>
+  BEST_TLIST_MUST_USE(push)
   static constexpr auto push();
 
   /// # `tlist::insert()`
@@ -225,8 +247,10 @@ class tlist final {
   /// Produces an SFINAE error when out-of-bounds, unless `Default` is
   /// specified, in which case that is returned instead.
   template <size_t n, typename T, typename Default = strict>
+  BEST_TLIST_MUST_USE(insert)
   static constexpr auto insert();
   template <size_t n, auto v, typename Default = strict>
+  BEST_TLIST_MUST_USE(insert)
   static constexpr auto insert();
 
   /// # `tlist::splice()`
@@ -237,6 +261,7 @@ class tlist final {
   /// Produces an SFINAE error when out-of-bounds, unless `Default` is
   /// specified, in which case that is returned instead.
   template <best::bounds bounds, typename Default = strict>
+  BEST_TLIST_MUST_USE(splice)
   static constexpr auto splice(best::is_tlist auto that);
 
   /// # `tlist::scatter()`
@@ -245,6 +270,7 @@ class tlist final {
   ///
   /// Ouf-of-bounds "writes" are discarded.
   template <auto those, size_t... ns>
+  BEST_TLIST_MUST_USE(scatter)
   static constexpr auto scatter()
     requires best::is_tlist_of_size<decltype(those), sizeof...(ns)>
   {
@@ -257,8 +283,10 @@ class tlist final {
   ///
   /// Ouf-of-bounds "writes" are discarded.
   template <size_t n, typename T>
+  BEST_TLIST_MUST_USE(update)
   static constexpr auto update();
   template <size_t n, auto v>
+  BEST_TLIST_MUST_USE(update)
   static constexpr auto update();
 
   /// # `tlist::remove()`
@@ -268,6 +296,7 @@ class tlist final {
   /// Produces an SFINAE error when out-of-bounds, unless `Default` is
   /// specified.
   template <size_t n, typename Default = strict>
+  BEST_TLIST_MUST_USE(remove)
   static constexpr auto remove();
 
   /// # `tlist::erase()`
@@ -278,6 +307,7 @@ class tlist final {
   /// Produces an SFINAE error when out-of-bounds, unless `Default` is
   /// specified.
   template <best::bounds bounds, typename Default = strict>
+  BEST_TLIST_MUST_USE(erase)
   static constexpr auto erase();
 
   /// # `tlist::trim_prefix()`
@@ -285,6 +315,7 @@ class tlist final {
   /// If `list` is a prefix of this tlist, returns a new tlist with those
   /// elements chopped off.
   template <typename Default = strict>
+  BEST_TLIST_MUST_USE(trim_prefix)
   static constexpr auto trim_prefix(best::is_tlist auto prefix);
 
   /// # `tlist::trim_prefix()`
@@ -292,7 +323,10 @@ class tlist final {
   /// If `list` is a suffix of this tlist, returns a new tlist with those
   /// elements chopped off.
   template <typename Default = strict>
+  BEST_TLIST_MUST_USE(trim_suffix)
   static constexpr auto trim_suffix(best::is_tlist auto suffix);
+
+#undef BEST_TLIST_MUST_USE
 
   /// # `tlist::find()`
   ///

--- a/best/meta/tlist.h
+++ b/best/meta/tlist.h
@@ -37,6 +37,27 @@
 //! represents a `typename...` and `auto...` pack, respectively.
 
 namespace best {
+/// # `best::is_tlist`, `best::is_vlist`
+///
+/// Whether a type is a tlist or vlist for some unknown set of template
+/// arguments.
+template <typename T>
+concept is_tlist = requires(T t) { tlist_internal::is_tlist(t); };
+template <typename T>
+concept is_vlist = requires(T t) {
+  tlist_internal::is_tlist(t);
+  requires T::is_values();
+};
+
+/// # `best::is_tlist_of_size`
+///
+/// Whether a type is a tlist of a specified size.
+template <typename T, size_t n>
+concept is_tlist_of_size = requires(T t) {
+  tlist_internal::is_tlist(t);
+  requires T::size() == n;
+};
+
 /// # `best::val<x>`
 ///
 /// A value-as-a-type.
@@ -92,6 +113,9 @@ concept same =
 /// `a` and `b` are incomparable.
 template <typename... Elems>
 class tlist final {
+ private:
+  using strict = tlist_internal::strict;
+
  public:
   constexpr tlist() = default;
   constexpr tlist(const tlist&) = default;
@@ -117,154 +141,42 @@ class tlist final {
   /// # `tlist::is_values()`
   ///
   /// Returns whether every element of this list is a `best::value_trait`.
-  static constexpr bool is_values() {
-    return (best::value_trait<Elems> && ...);
-  }
-
-  /// # `tlist::concat()`
-  ///
-  /// Concatenates several tlists with this one. If an argument to this type is
-  /// not a tlist, it is treated as a one-element tlist.
-  static constexpr auto concat(auto... those) {
-    return tlist_internal::concat<Elems...>(those...);
-  }
+  static constexpr bool is_values();
 
   /// # `best::unique_pack`
   ///
-  /// Whether this pack of types is a
-  template <typename... Ts>
-  static constexpr bool is_unique() {
-    return tlist_internal::uniq<Ts...>;
-  };
-
- private:
-  template <typename F>
-  static constexpr bool type_callable = (... && callable<F, void(), Elems>);
-  template <typename F>
-  static constexpr bool value_callable = !is_empty() && (... && requires {
-    Elems::value;
-    requires callable<F, void(decltype(Elems::value))>;
-  });
-
-  template <typename F>
-  static constexpr bool types_callable = callable<F, void(), Elems...>;
-
-  template <typename F>
-  static constexpr bool values_callable = !is_empty() && requires {
-    (Elems::value, ...);
-    requires callable<F, void(decltype(Elems::value)...)>;
-  };
-
- public:
-  /// # `tlist::map()`
-  ///
-  /// Applies a function or a type trait to each type in this list and returns a
-  /// new list with the results.
-  ///
-  /// `cb` can either take zero arguments and exactly one template parameter, or
-  /// exactly one argument. In the latter case, this must be a `vlist`. If
-  /// passing a trait instead, it must take either one `typename` or one `auto`.
-  template <auto cb>
-  static constexpr decltype(auto) map()
-    requires type_callable<decltype(cb)>
-  {
-    return vals<best::call<Elems>(cb)...>;
-  }
-  template <template <typename> typename Trait>
-  static constexpr decltype(auto) map() {
-    return types<Trait<Elems>...>;
-  }
-  template <auto cb>
-  static constexpr decltype(auto) map()
-    requires value_callable<decltype(cb)>
-  {
-    return vals<best::call(cb, Elems::value)...>;
-  }
-  template <template <auto> typename Trait>
-  static constexpr decltype(auto) map()
-    requires(is_values())
-  {
-    return types<Trait<Elems::values>...>;
-  }
-
-  /// # `tlist::each()`
-  ///
-  /// Applies `cb` to each type in this list as in `map()` but does not require
-  /// that `cb` return a value.
-  static constexpr void each(auto cb)
-    requires type_callable<decltype(cb)>
-  {
-    (best::call<Elems>(cb), ...);
-  }
-  static constexpr void each(auto cb)
-    requires value_callable<decltype(cb)>
-  {
-    (best::call(cb, Elems::value), ...);
-  }
-
-  /// # `tlist::apply()`
-  ///
-  /// Applies `cb` to *every* type in this list at once. `cb` may either have
-  /// a `typename...` parameter or an `auto...` argument.
-  static constexpr decltype(auto) apply(auto cb)
-    requires types_callable<decltype(cb)>
-  {
-    return best::call<Elems...>(cb);
-  }
-  static constexpr decltype(auto) apply(auto cb)
-    requires values_callable<decltype(cb)>
-  {
-    return best::call(cb, Elems::value...);
-  };
-
-  /// # `tlist::reduce()`
-  ///
-  /// Reduces this vlist by applying op to each element's value..
-  template <best::op op>
-  static constexpr decltype(auto) reduce()
-    requires(is_values())
-  {
-    return best::operate<op>(Elems::value...);
-  }
+  /// Whether this pack of types has no duplicates.
+  static constexpr bool is_unique() { return tlist_internal::uniq<Elems...>; };
 
   /// # `tlist::reduce()`
   ///
   /// Reduces this vlist by applying `&&`.
-  static constexpr decltype(auto) all()
-    requires(is_values())
-  {
-    return reduce<best::op::AndAnd>();
-  };
+  static constexpr decltype(auto) all() { return reduce<best::op::AndAnd>(); };
 
   /// # `tlist::reduce()`
   ///
   /// Reduces this vlist by applying `||`.
-  static constexpr decltype(auto) any()
-    requires(is_values())
-  {
-    return reduce<best::op::OrOr>();
-  };
+  static constexpr decltype(auto) any() { return reduce<best::op::OrOr>(); };
 
   /// # `tlist::type<n>`
   ///
   /// Gets the type of the `n`th element of this tag.
   ///
   /// Produces an SFINAE error when out-of-bounds, unless `Default` is
-  /// specified.
-  template <size_t n, typename Default = tlist_internal::strict>
-  using type = tlist_internal::nth<n, Default, Elems...>;
+  /// specified, in which case that is returned instead.
+  template <size_t n, typename Default = strict>
+  using type = tlist_internal::nth<n, Default, tlist>;
 
   /// # `tlist::value<n>`
   ///
   /// Gets the value of the `n`th element of this tag.
   ///
   /// Produces an SFINAE error when out-of-bounds, unless `default_` is
-  /// specified.
-  template <size_t n, auto default_ = tlist_internal::strict{}>
+  /// specified, in which case that is returned instead.
+  template <size_t n, auto default_ = strict{}>
   static constexpr auto value =
-      type<n, best::select<
-                  std::is_same_v<decltype(default_), tlist_internal::strict>,
-                  tlist_internal::strict, val<default_>>>::value;
+      type<n, best::select<tlist_internal::not_strict<decltype(default_)>,
+                           tlist_internal::strict, val<default_>>>::value;
 
   /// # `tlist::at()`
   ///
@@ -272,76 +184,141 @@ class tlist final {
   /// corresponding types.
   ///
   /// Produces an SFINAE error when out-of-bounds, unless `Default` is
+  /// specified, in which case that is returned instead.
+  template <best::bounds bounds, typename Default = strict>
+  static constexpr auto at();
+
+  /// # `tlist::gather()`
+  ///
+  /// Selects elements of this tlist by index to form a new tlist.
+  ///
+  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
   /// specified.
-  template <best::bounds bounds, typename Default = tlist_internal::strict>
-  static constexpr tlist_internal::slice<bounds, Default, tlist> at() {
-    return {};
+  template <size_t... ns>
+  static constexpr auto gather();
+  template <typename Default, size_t... ns>
+  static constexpr auto gather();
+
+  /// # `tlist::join()`, `tlist::operator+`
+  ///
+  /// Concatenates several tlists with this one. If an argument to this type is
+  /// not a tlist, it is treated as a one-element tlist.
+  ///
+  /// This is also made available via `operator+`, but beware: using a fold with
+  /// `operator+` here is quadratic; you should generally prefer `join()` for
+  /// variadic cases.
+  static constexpr auto join(best::is_tlist auto... those);
+  auto operator+(best::is_tlist auto that) { return join(that); }
+
+  /// # `tlist::push()`
+  ///
+  /// Inserts a new value at the end of the list.
+  template <typename T>
+  static constexpr auto push();
+  template <auto v>
+  static constexpr auto push();
+
+  /// # `tlist::insert()`
+  ///
+  /// Inserts a new value at the specified index.
+  ///
+  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
+  /// specified, in which case that is returned instead.
+  template <size_t n, typename T, typename Default = strict>
+  static constexpr auto insert();
+  template <size_t n, auto v, typename Default = strict>
+  static constexpr auto insert();
+
+  /// # `tlist::splice()`
+  ///
+  /// Slices into `Elems` with `bounds` and returns a new tlist with the
+  /// sliced portion replaced with `those`.
+  ///
+  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
+  /// specified, in which case that is returned instead.
+  template <best::bounds bounds, typename Default = strict>
+  static constexpr auto splice(best::is_tlist auto that);
+
+  /// # `tlist::scatter()`
+  ///
+  /// Updates elements of this tlist by selecting from the list provided.
+  ///
+  /// Ouf-of-bounds "writes" are discarded.
+  template <auto those, size_t... ns>
+  static constexpr auto scatter()
+    requires best::is_tlist_of_size<decltype(those), sizeof...(ns)>
+  {
+    return tlist_internal::scatter<tlist, decltype(those), ns...>{};
   }
+
+  /// # `tlist::update()`
+  ///
+  /// Updates a single element of this list.
+  ///
+  /// Ouf-of-bounds "writes" are discarded.
+  template <size_t n, typename T>
+  static constexpr auto update();
+  template <size_t n, auto v>
+  static constexpr auto update();
+
+  /// # `tlist::remove()`
+  ///
+  /// Removes the element at index `n`.
+  ///
+  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
+  /// specified.
+  template <size_t n, typename Default = strict>
+  static constexpr auto remove();
+
+  /// # `tlist::erase()`
+  ///
+  /// Slices into `Elems` with `bounds` and returns a new tlist tlist with the
+  /// sliced portion removed.
+  ///
+  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
+  /// specified.
+  template <best::bounds bounds, typename Default = strict>
+  static constexpr auto erase();
 
   /// # `tlist::trim_prefix()`
   ///
   /// If `list` is a prefix of this tlist, returns a new tlist with those
   /// elements chopped off.
-  template <typename Default = tlist_internal::strict>
-  static constexpr auto trim_prefix(auto list) {
-    using D = best::select<std::is_same_v<Default, tlist_internal::strict>,
-                           tlist, Default>;
-    using Out = decltype(list.remove_prefix_from(tlist{}));
-    if constexpr (std::is_void_v<Out>) {
-      return D{};
-    } else {
-      return Out{};
-    }
-  }
+  template <typename Default = strict>
+  static constexpr auto trim_prefix(best::is_tlist auto prefix);
 
   /// # `tlist::trim_prefix()`
   ///
   /// If `list` is a suffix of this tlist, returns a new tlist with those
   /// elements chopped off.
-  template <typename Default = tlist_internal::strict>
-  static constexpr auto trim_suffix(auto list) {
-    using D = best::select<std::is_same_v<Default, tlist_internal::strict>,
-                           tlist, Default>;
-    using Out = decltype(list.remove_suffix_from(tlist{}));
-    if constexpr (std::is_void_v<Out>) {
-      return D{};
-    } else {
-      return Out{};
-    }
-  }
+  template <typename Default = strict>
+  static constexpr auto trim_suffix(best::is_tlist auto suffix);
 
   /// # `tlist::find()`
   ///
   /// Returns the first index of this list that satisfies the given type
   /// predicate. This predicate can be a callback (as in `map()`), a bool-typed
   /// value trait, or a type/value to search for.
-  static constexpr best::container_internal::option<size_t> find(auto pred)
-    requires type_callable<decltype(pred)>
-  {
+  static constexpr auto find(tlist_internal::t_callable<Elems...> auto pred) {
     size_t n = -1;
     if (((++n, best::call<Elems>(pred)) || ...)) {
-      return n;
+      return opt_size(n);
     }
-    return {};
+    return opt_size{};
   }
-  static constexpr best::container_internal::option<size_t> find(auto pred)
-    requires value_callable<decltype(pred)>
-  {
+  static constexpr auto find(tlist_internal::v_callable<Elems...> auto pred) {
     return find([&]<typename V> { return pred(V::value); });
   }
   template <typename T>
-  static constexpr best::container_internal::option<size_t> find() {
+  static constexpr auto find() {
     return find([]<typename U> { return std::same_as<T, U>; });
   }
   template <template <typename> typename Trait>
-  static constexpr best::container_internal::option<size_t> find()
-    requires(... && value_trait<Trait<Elems>>)
-  {
+  static constexpr auto find() {
     return find([]<typename U> { return Trait<U>::value; });
   }
-  static constexpr best::container_internal::option<size_t> find(auto value)
-    requires(!value_callable<decltype(value)> && ... &&
-             best::equatable<decltype(value), decltype(Elems::value)>)
+  static constexpr auto find(auto value)
+    requires(best::equatable<decltype(value), decltype(Elems::value)> && ...)
   {
     return find([&](auto that) { return value == that; });
   }
@@ -349,64 +326,96 @@ class tlist final {
   /// # `tlist::find_unique()`
   ///
   /// Like `find()`, but requires that the returned element be the unique match.
-  static constexpr best::container_internal::option<size_t> find_unique(
-      auto pred)
-    requires type_callable<decltype(pred)>
-  {
+  static constexpr auto find_unique(
+      tlist_internal::t_callable<Elems...> auto pred) {
     size_t n = -1;
     size_t found = 0;
     if ((((found || ++n), best::call<Elems>(pred) && (++found == 2)) || ...) ||
         found != 1) {
-      return {};
+      return opt_size{};
     }
-    return n;
+    return opt_size{n};
   }
-  static constexpr best::container_internal::option<size_t> find_unique(
-      auto pred)
-    requires value_callable<decltype(pred)>
-  {
+  static constexpr auto find_unique(
+      tlist_internal::v_callable<Elems...> auto pred) {
     return find_unique([&]<typename V> { return pred(V::value); });
   }
   template <typename T>
-  static constexpr best::container_internal::option<size_t> find_unique() {
+  static constexpr auto find_unique() {
     return find_unique([]<typename U> { return std::same_as<T, U>; });
   }
   template <template <typename> typename Trait>
-  static constexpr best::container_internal::option<size_t> find_unique()
+  static constexpr auto find_unique()
     requires(... && value_trait<Trait<Elems>>)
   {
     return find_unique([]<typename U> { return Trait<U>::value; });
   }
-  static constexpr best::container_internal::option<size_t> find_unique(
-      auto value)
-    requires(!value_callable<decltype(value)> && ... &&
-             best::equatable<decltype(value), decltype(Elems::value)>)
+  static constexpr auto find_unique(auto value)
+    requires(best::equatable<decltype(value), decltype(Elems::value)> && ...)
   {
     return find_unique([&](auto that) { return value == that; });
   }
 
-  constexpr bool operator==(tlist) const { return true; }
-  template <typename... Those>
-  constexpr bool operator==(tlist<Those...>) const {
-    return false;
+  /// # `tlist::map()`
+  ///
+  /// Applies a function or a type trait to each type in this list and returns a
+  /// new list with the results.
+  ///
+  /// `cb` can either take zero arguments and exactly one template parameter, or
+  /// exactly one argument. In the latter case, this tlist must be a vlist. If
+  /// passing a trait instead, it must take either one `typename` or one `auto`.
+  template <tlist_internal::t_callable<Elems...> auto cb>
+  static constexpr decltype(auto) map() {
+    return best::vals<best::call<Elems>(cb)...>;
   }
-  template <typename... Those>
-  constexpr best::partial_ord operator<=>(tlist<Those...> that) const {
-    if constexpr (tlist{} == that) {
-      return best::partial_ord::equivalent;
-    } else if constexpr (!std::is_void_v<decltype(remove_prefix_from(that))>) {
-      return best::partial_ord::less;
-    } else if constexpr (!std::is_void_v<decltype(that.remove_prefix_from(
-                             tlist{}))>) {
-      return best::partial_ord::greater;
-    } else {
-      return best::partial_ord::unordered;
-    }
+  template <tlist_internal::v_callable<Elems...> auto cb>
+  static constexpr decltype(auto) map() {
+    return best::vals<best::call(cb, Elems::value)...>;
   }
+  template <template <typename> typename Trait>
+  static constexpr decltype(auto) map();
+  template <template <auto> typename Trait>
+  static constexpr decltype(auto) map();
+
+  /// # `tlist::each()`
+  ///
+  /// Applies `cb` to each type in this list as in `map()` but does not require
+  /// that `cb` return a value.
+  static constexpr void each(tlist_internal::t_callable<Elems...> auto cb) {
+    (best::call<Elems>(cb), ...);
+  }
+  static constexpr void each(tlist_internal::v_callable<Elems...> auto cb) {
+    (best::call(cb, Elems::value), ...);
+  }
+
+  /// # `tlist::apply()`
+  ///
+  /// Applies `cb` to *every* type in this list at once. `cb` may either have
+  /// a `typename...` parameter or an `auto...` argument.
+  static constexpr decltype(auto) apply(
+      tlist_internal::ts_callable<Elems...> auto cb) {
+    return best::call<Elems...>(cb);
+  }
+  static constexpr decltype(auto) apply(
+      tlist_internal::vs_callable<Elems...> auto cb) {
+    return best::call(cb, Elems::value...);
+  };
+
+  /// # `tlist::reduce()`
+  ///
+  /// Reduces this vlist by applying op to each element's value..
+  template <best::op op>
+  static constexpr decltype(auto) reduce() {
+    return best::operate<op>(Elems::value...);
+  }
+
+  constexpr bool operator==(best::is_tlist auto) const;
+  constexpr best::partial_ord operator<=>(best::is_tlist auto that) const;
 
  private:
   template <typename...>
   friend class tlist;
+  using opt_size = best::container_internal::option<size_t>;
 
   template <typename... Extra>
   static constexpr tlist<Extra...> remove_prefix_from(
@@ -422,6 +431,143 @@ class tlist final {
   }
   static constexpr void remove_suffix_from(auto) {}
 };
+}  // namespace best
+
+/* ////////////////////////////////////////////////////////////////////////// *\
+ * ////////////////// !!! IMPLEMENTATION DETAILS BELOW !!! ////////////////// *
+\* ////////////////////////////////////////////////////////////////////////// */
+
+namespace best {
+template <typename... Elems>
+constexpr bool tlist<Elems...>::is_values() {
+  return (best::value_trait<Elems> && ...);
+}
+
+template <typename... Elems>
+constexpr auto tlist<Elems...>::join(best::is_tlist auto... those) {
+  return tlist_internal::join<tlist, decltype(those)...>{};
+}
+
+template <typename... Elems>
+template <template <typename> typename Trait>
+constexpr decltype(auto) tlist<Elems...>::map() {
+  return types<Trait<Elems>...>;
+}
+template <typename... Elems>
+template <template <auto> typename Trait>
+constexpr decltype(auto) tlist<Elems...>::map() {
+  return types<Trait<Elems::values>...>;
+}
+
+template <typename... Elems>
+template <best::bounds bounds, typename Default>
+constexpr auto tlist<Elems...>::at() {
+  return tlist_internal::slice<bounds, Default, tlist>{};
+}
+
+template <typename... Elems>
+template <typename T>
+constexpr auto tlist<Elems...>::push() {
+  return insert<size(), T>();
+}
+template <typename... Elems>
+template <auto v>
+constexpr auto tlist<Elems...>::push() {
+  return insert<size(), v>();
+}
+
+template <typename... Elems>
+template <size_t n, typename T, typename Default>
+constexpr auto tlist<Elems...>::insert() {
+  return splice<bounds{.start = n, .count = 0}, Default>(best::types<T>);
+}
+template <typename... Elems>
+template <size_t n, auto v, typename Default>
+constexpr auto tlist<Elems...>::insert() {
+  return splice<bounds{.start = n, .count = 0}, Default>(best::vals<v>);
+}
+
+template <typename... Elems>
+template <best::bounds bounds, typename Default>
+constexpr auto tlist<Elems...>::splice(best::is_tlist auto that) {
+  return tlist_internal::splice<bounds, Default, tlist, decltype(that)>{};
+}
+
+template <typename... Elems>
+template <size_t... ns>
+constexpr auto tlist<Elems...>::gather() {
+  return tlist_internal::gather<best::tlist_internal::strict, tlist, ns...>{};
+}
+template <typename... Elems>
+template <typename Default, size_t... ns>
+constexpr auto tlist<Elems...>::gather() {
+  return tlist_internal::gather<Default, tlist, ns...>{};
+}
+
+template <typename... Elems>
+template <size_t n, typename T>
+constexpr auto tlist<Elems...>::update() {
+  return splice<bounds{.start = n, .count = 0}, tlist>(best::types<T>);
+}
+template <typename... Elems>
+template <size_t n, auto v>
+constexpr auto tlist<Elems...>::update() {
+  return splice<bounds{.start = n, .count = 0}, tlist>(best::vals<v>);
+}
+
+template <typename... Elems>
+template <size_t n, typename Default>
+constexpr auto tlist<Elems...>::remove() {
+  return splice<bounds{.start = n, .count = 1}, Default>(best::types<>);
+}
+
+template <typename... Elems>
+template <best::bounds bounds, typename Default>
+constexpr auto tlist<Elems...>::erase() {
+  return splice<bounds, Default>(best::types<>);
+}
+
+template <typename... Elems>
+template <typename Default>
+constexpr auto tlist<Elems...>::trim_prefix(best::is_tlist auto list) {
+  using D = best::select<tlist_internal::not_strict<Default>, Default, tlist>;
+  using Out = decltype(list.remove_prefix_from(tlist{}));
+  if constexpr (std::is_void_v<Out>) {
+    return D{};
+  } else {
+    return Out{};
+  }
+}
+template <typename... Elems>
+template <typename Default>
+constexpr auto tlist<Elems...>::trim_suffix(best::is_tlist auto list) {
+  using D = best::select<tlist_internal::not_strict<Default>, Default, tlist>;
+  using Out = decltype(list.remove_suffix_from(tlist{}));
+  if constexpr (std::is_void_v<Out>) {
+    return D{};
+  } else {
+    return Out{};
+  }
+}
+
+template <typename... Elems>
+constexpr bool tlist<Elems...>::operator==(best::is_tlist auto that) const {
+  return std::is_same_v<tlist, decltype(that)>;
+}
+template <typename... Elems>
+constexpr best::partial_ord tlist<Elems...>::operator<=>(
+    best::is_tlist auto that) const {
+  if constexpr (tlist{} == that) {
+    return best::partial_ord::equivalent;
+  } else if constexpr (!std::is_void_v<decltype(remove_prefix_from(that))>) {
+    return best::partial_ord::less;
+  } else if constexpr (!std::is_void_v<decltype(that.remove_prefix_from(
+                           tlist{}))>) {
+    return best::partial_ord::greater;
+  } else {
+    return best::partial_ord::unordered;
+  }
+}
 }  // namespace best
 
 #endif  // BEST_META_TLIST_H_

--- a/best/meta/tlist.h
+++ b/best/meta/tlist.h
@@ -203,6 +203,74 @@ class tlist final {
   template <best::bounds bounds, typename Default = strict>
   static constexpr auto at();
 
+  /// # `tlist::join()`, `tlist::operator+`
+  ///
+  /// Concatenates several tlists with this one.
+  ///
+  /// This is also made available via `operator+`, but beware: using a fold with
+  /// `operator+` here is quadratic; you should generally prefer `join()` for
+  /// variadic cases.
+  static constexpr auto join(best::is_tlist auto... those);
+  auto operator+(best::is_tlist auto that) { return join(that); }
+
+  /// # `tlist::push()`
+  ///
+  /// Inserts a new value at the end of the list.
+  template <typename T>
+  static constexpr auto push();
+  template <auto v>
+  static constexpr auto push();
+
+  /// # `tlist::insert()`
+  ///
+  /// Inserts a new value at the specified index.
+  ///
+  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
+  /// specified, in which case that is returned instead.
+  template <size_t n, typename T, typename Default = strict>
+  static constexpr auto insert();
+  template <size_t n, auto v, typename Default = strict>
+  static constexpr auto insert();
+
+  /// # `tlist::update()`
+  ///
+  /// Updates a single element of this list.
+  ///
+  /// Ouf-of-bounds "writes" are discarded.
+  template <size_t n, typename T>
+  static constexpr auto update();
+  template <size_t n, auto v>
+  static constexpr auto update();
+
+  /// # `tlist::splice()`
+  ///
+  /// Slices into `Elems` with `bounds` and returns a new tlist with the
+  /// sliced portion replaced with `those`.
+  ///
+  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
+  /// specified, in which case that is returned instead.
+  template <best::bounds bounds, typename Default = strict>
+  static constexpr auto splice(best::is_tlist auto that);
+
+  /// # `tlist::remove()`
+  ///
+  /// Removes the element at index `n`.
+  ///
+  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
+  /// specified.
+  template <size_t n, typename Default = strict>
+  static constexpr auto remove();
+
+  /// # `tlist::erase()`
+  ///
+  /// Slices into `Elems` with `bounds` and returns a new tlist tlist with the
+  /// sliced portion removed.
+  ///
+  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
+  /// specified.
+  template <best::bounds bounds, typename Default = strict>
+  static constexpr auto erase();
+
   /// # `tlist::gather()`
   ///
   /// Selects elements of this tlist by index to form a new tlist.
@@ -214,106 +282,20 @@ class tlist final {
   template <typename Default, size_t... ns>
   static constexpr auto gather();
 
-  /// # `tlist::join()`, `tlist::operator+`
-  ///
-  /// Concatenates several tlists with this one.
-  ///
-  /// This is also made available via `operator+`, but beware: using a fold with
-  /// `operator+` here is quadratic; you should generally prefer `join()` for
-  /// variadic cases.
-  static constexpr auto join(best::is_tlist auto... those);
-  auto operator+(best::is_tlist auto that) { return join(that); }
-
-#define BEST_TLIST_MUST_USE(func_)                            \
-  [[nodiscard("best::tlist::" #func_                          \
-              "() does not mutate its argument; instead, it " \
-              "returns a new best::tlist")]]
-
-  /// # `tlist::push()`
-  ///
-  /// Inserts a new value at the end of the list.
-  template <typename T>
-  BEST_TLIST_MUST_USE(push)
-  static constexpr auto push();
-  template <auto v>
-  BEST_TLIST_MUST_USE(push)
-  static constexpr auto push();
-
-  /// # `tlist::insert()`
-  ///
-  /// Inserts a new value at the specified index.
-  ///
-  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
-  /// specified, in which case that is returned instead.
-  template <size_t n, typename T, typename Default = strict>
-  BEST_TLIST_MUST_USE(insert)
-  static constexpr auto insert();
-  template <size_t n, auto v, typename Default = strict>
-  BEST_TLIST_MUST_USE(insert)
-  static constexpr auto insert();
-
-  /// # `tlist::splice()`
-  ///
-  /// Slices into `Elems` with `bounds` and returns a new tlist with the
-  /// sliced portion replaced with `those`.
-  ///
-  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
-  /// specified, in which case that is returned instead.
-  template <best::bounds bounds, typename Default = strict>
-  BEST_TLIST_MUST_USE(splice)
-  static constexpr auto splice(best::is_tlist auto that);
-
   /// # `tlist::scatter()`
   ///
   /// Updates elements of this tlist by selecting from the list provided.
   ///
   /// Ouf-of-bounds "writes" are discarded.
-  template <size_t... ns>
-  BEST_TLIST_MUST_USE(scatter)
+  template <size_t... n>
   static constexpr auto scatter(
-      best::is_tlist_of_size<sizeof...(ns)> auto those) {
-    return tlist_internal::scatter<tlist, decltype(those), ns...>{};
-  }
-
-  /// # `tlist::update()`
-  ///
-  /// Updates a single element of this list.
-  ///
-  /// Ouf-of-bounds "writes" are discarded.
-  template <size_t n, typename T>
-  BEST_TLIST_MUST_USE(update)
-  static constexpr auto update();
-  template <size_t n, auto v>
-  BEST_TLIST_MUST_USE(update)
-  static constexpr auto update();
-
-  /// # `tlist::remove()`
-  ///
-  /// Removes the element at index `n`.
-  ///
-  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
-  /// specified.
-  template <size_t n, typename Default = strict>
-  BEST_TLIST_MUST_USE(remove)
-  static constexpr auto remove();
-
-  /// # `tlist::erase()`
-  ///
-  /// Slices into `Elems` with `bounds` and returns a new tlist tlist with the
-  /// sliced portion removed.
-  ///
-  /// Produces an SFINAE error when out-of-bounds, unless `Default` is
-  /// specified.
-  template <best::bounds bounds, typename Default = strict>
-  BEST_TLIST_MUST_USE(erase)
-  static constexpr auto erase();
+      best::is_tlist_of_size<sizeof...(n)> auto those);
 
   /// # `tlist::trim_prefix()`
   ///
   /// If `list` is a prefix of this tlist, returns a new tlist with those
   /// elements chopped off.
   template <typename Default = strict>
-  BEST_TLIST_MUST_USE(trim_prefix)
   static constexpr auto trim_prefix(best::is_tlist auto prefix);
 
   /// # `tlist::trim_prefix()`
@@ -321,10 +303,7 @@ class tlist final {
   /// If `list` is a suffix of this tlist, returns a new tlist with those
   /// elements chopped off.
   template <typename Default = strict>
-  BEST_TLIST_MUST_USE(trim_suffix)
   static constexpr auto trim_suffix(best::is_tlist auto suffix);
-
-#undef BEST_TLIST_MUST_USE
 
   /// # `tlist::find()`
   ///
@@ -478,6 +457,12 @@ class tlist final {
 \* ////////////////////////////////////////////////////////////////////////// */
 
 namespace best {
+
+#define BEST_TLIST_MUST_USE(func_)                            \
+  [[nodiscard("best::tlist::" #func_                          \
+              "() does not mutate its argument; instead, it " \
+              "returns a new best::tlist")]]
+
 template <typename... Elems>
 constexpr bool tlist<Elems...>::is_values() {
   return (best::value_trait<Elems> && ...);
@@ -507,28 +492,33 @@ constexpr auto tlist<Elems...>::at() {
 
 template <typename... Elems>
 template <typename T>
+BEST_TLIST_MUST_USE(push)
 constexpr auto tlist<Elems...>::push() {
   return insert<size(), T>();
 }
 template <typename... Elems>
 template <auto v>
+BEST_TLIST_MUST_USE(push)
 constexpr auto tlist<Elems...>::push() {
   return insert<size(), v>();
 }
 
 template <typename... Elems>
 template <size_t n, typename T, typename Default>
+BEST_TLIST_MUST_USE(insert)
 constexpr auto tlist<Elems...>::insert() {
   return splice<bounds{.start = n, .count = 0}, Default>(best::types<T>);
 }
 template <typename... Elems>
 template <size_t n, auto v, typename Default>
+BEST_TLIST_MUST_USE(insert)
 constexpr auto tlist<Elems...>::insert() {
   return splice<bounds{.start = n, .count = 0}, Default>(best::vals<v>);
 }
 
 template <typename... Elems>
 template <best::bounds bounds, typename Default>
+BEST_TLIST_MUST_USE(splice)
 constexpr auto tlist<Elems...>::splice(best::is_tlist auto that) {
   return tlist_internal::splice<bounds, Default, tlist, decltype(that)>{};
 }
@@ -545,30 +535,43 @@ constexpr auto tlist<Elems...>::gather() {
 }
 
 template <typename... Elems>
+template <size_t... n>
+BEST_TLIST_MUST_USE(scatter)
+constexpr auto tlist<Elems...>::scatter(
+    best::is_tlist_of_size<sizeof...(n)> auto those) {
+  return tlist_internal::scatter<tlist, decltype(those), n...>{};
+}
+
+template <typename... Elems>
 template <size_t n, typename T>
+BEST_TLIST_MUST_USE(update)
 constexpr auto tlist<Elems...>::update() {
   return splice<bounds{.start = n, .count = 0}, tlist>(best::types<T>);
 }
 template <typename... Elems>
 template <size_t n, auto v>
+BEST_TLIST_MUST_USE(update)
 constexpr auto tlist<Elems...>::update() {
   return splice<bounds{.start = n, .count = 0}, tlist>(best::vals<v>);
 }
 
 template <typename... Elems>
 template <size_t n, typename Default>
+BEST_TLIST_MUST_USE(remove)
 constexpr auto tlist<Elems...>::remove() {
   return splice<bounds{.start = n, .count = 1}, Default>(best::types<>);
 }
 
 template <typename... Elems>
 template <best::bounds bounds, typename Default>
+BEST_TLIST_MUST_USE(erase)
 constexpr auto tlist<Elems...>::erase() {
   return splice<bounds, Default>(best::types<>);
 }
 
 template <typename... Elems>
 template <typename Default>
+BEST_TLIST_MUST_USE(trim_prefix)
 constexpr auto tlist<Elems...>::trim_prefix(best::is_tlist auto list) {
   using D = best::select<tlist_internal::not_strict<Default>, Default, tlist>;
   using Out = decltype(list.remove_prefix_from(tlist{}));
@@ -580,6 +583,7 @@ constexpr auto tlist<Elems...>::trim_prefix(best::is_tlist auto list) {
 }
 template <typename... Elems>
 template <typename Default>
+BEST_TLIST_MUST_USE(trim_suffix)
 constexpr auto tlist<Elems...>::trim_suffix(best::is_tlist auto list) {
   using D = best::select<tlist_internal::not_strict<Default>, Default, tlist>;
   using Out = decltype(list.remove_suffix_from(tlist{}));
@@ -608,6 +612,7 @@ constexpr best::partial_ord tlist<Elems...>::operator<=>(
     return best::partial_ord::unordered;
   }
 }
+#undef BEST_TLIST_MUST_USE
 }  // namespace best
 
 #endif  // BEST_META_TLIST_H_

--- a/best/meta/tlist.h
+++ b/best/meta/tlist.h
@@ -268,11 +268,10 @@ class tlist final {
   /// Updates elements of this tlist by selecting from the list provided.
   ///
   /// Ouf-of-bounds "writes" are discarded.
-  template <auto those, size_t... ns>
+  template <size_t... ns>
   BEST_TLIST_MUST_USE(scatter)
-  static constexpr auto scatter()
-    requires best::is_tlist_of_size<decltype(those), sizeof...(ns)>
-  {
+  static constexpr auto scatter(
+      best::is_tlist_of_size<sizeof...(ns)> auto those) {
     return tlist_internal::scatter<tlist, decltype(those), ns...>{};
   }
 

--- a/best/meta/tlist_test.cc
+++ b/best/meta/tlist_test.cc
@@ -57,7 +57,7 @@ static_assert(best::vals<1, 2, 3, 4>.at<bounds{.start = 1, .count = 2}>() ==
               best::vals<2, 3>);
 
 static_assert(best::vals<1, 2, 3, 4>.gather<2, 3, 0>() == best::vals<3, 4, 1>);
-static_assert(best::vals<1, 2, 3, 4>.scatter<best::vals<4, 5>, 2, 0>() ==
+static_assert(best::vals<1, 2, 3, 4>.scatter<2, 0>(best::vals<4, 5>) ==
               best::vals<5, 2, 4, 4>);
 
 static_assert(best::vals<1, 2, 3, 4>.push<5>() == best::vals<1, 2, 3, 4, 5>);

--- a/best/meta/tlist_test.cc
+++ b/best/meta/tlist_test.cc
@@ -56,6 +56,22 @@ static_assert(two.map<std::is_integral>().reduce<best::op::Add>() == 2);
 static_assert(best::vals<1, 2, 3, 4>.at<bounds{.start = 1, .count = 2}>() ==
               best::vals<2, 3>);
 
+static_assert(best::vals<1, 2, 3, 4>.gather<2, 3, 0>() == best::vals<3, 4, 1>);
+static_assert(best::vals<1, 2, 3, 4>.scatter<best::vals<4, 5>, 2, 0>() ==
+              best::vals<5, 2, 4, 4>);
+
+static_assert(best::vals<1, 2, 3, 4>.push<5>() == best::vals<1, 2, 3, 4, 5>);
+static_assert(best::vals<1, 2, 3, 4>.insert<2, 5>() ==
+              best::vals<1, 2, 5, 3, 4>);
+static_assert(best::vals<1, 2, 3, 4>.splice<best::bounds{.start = 1, .end = 3}>(
+                  best::vals<9, 8, 7>) == best::vals<1, 9, 8, 7, 4>);
+
+static_assert(best::vals<1, 2, 3, 4>.remove<3>() == best::vals<1, 2, 3>);
+static_assert(best::vals<1, 2, 3, 4>.remove<1>() == best::vals<1, 3, 4>);
+static_assert(
+    best::vals<1, 2, 3, 4>.erase<best::bounds{.start = 1, .end = 3}>() ==
+    best::vals<1, 4>);
+
 static_assert(best::types<int*, int, void*>.find<std::is_integral>() == 1);
 static_assert(
     !best::types<int*, int, void*>.find<std::is_floating_point>().has_value());
@@ -72,8 +88,10 @@ static_assert(best::vals<1, 2, 3>.find_unique(3) == 2);
 static_assert(!best::vals<1, 3, 3>.find_unique(3).has_value());
 static_assert(!best::vals<1, 3, 3>.find_unique(4).has_value());
 
-static_assert(best::vals<1, 2, 3>.concat(best::vals<4, 5, 6>) ==
+static_assert(best::vals<1, 2, 3>.join(best::vals<4, 5, 6>) ==
               best::vals<1, 2, 3, 4, 5, 6>);
+
+static_assert(best::vals<1, 2, 3>.join(best::vals<>) == best::vals<1, 2, 3>);
 
 }  // namespace best::tlist_test
 

--- a/best/meta/traits.h
+++ b/best/meta/traits.h
@@ -26,6 +26,15 @@
 //! traits are implemented by `<type_traits>` but have horrendous names.
 
 namespace best {
+/// # `best::id<T>`
+///
+/// The identity type trait. Useful for turning any single type into a tag, when
+/// you don't need the full power of `best::tlist`.
+template <typename T>
+struct id final {
+  using type = T;
+};
+
 /// # `best::type_trait`
 ///
 /// Whether `T` is a type trait, i.e., a type with an alias member named `type`.

--- a/best/test/fodder.h
+++ b/best/test/fodder.h
@@ -92,6 +92,17 @@ class TrivialCopy final {
   constexpr TrivialCopy& operator=(const TrivialCopy&) = default;
 };
 
+class MoveOnly final {
+ public:
+  constexpr MoveOnly() {}
+  constexpr MoveOnly(const MoveOnly&) = delete;
+  constexpr MoveOnly& operator=(const MoveOnly&) = delete;
+  constexpr MoveOnly(MoveOnly&&) = default;
+  constexpr MoveOnly& operator=(MoveOnly&&) = default;
+
+  constexpr int frob() && { return 42; }
+};
+
 class Stuck final {
  public:
   constexpr Stuck() {}

--- a/best/text/internal/format_parser_test.cc
+++ b/best/text/internal/format_parser_test.cc
@@ -67,157 +67,140 @@ best::test ParseOk = [](auto& t) {
                   best::str("}"), best::str("!")});
 
   t.expect_eq(parse("{}"),  //
-              Ast{{best::row{0, format_spec{}}.forward()}});
+              Ast{{best::args(0, format_spec{})}});
 
   t.expect_eq(parse("{} "),  //
-              Ast{{best::row{0, format_spec{}}.forward(), best::str(" ")}});
+              Ast{{best::args(0, format_spec{}), best::str(" ")}});
 
   t.expect_eq(parse(" {}"),  //
-              Ast{{best::str(" "), best::row{0, format_spec{}}.forward()}});
+              Ast{{best::str(" "), best::args(0, format_spec{})}});
 
   t.expect_eq(parse("hello, {}!"),  //
               Ast{{
                   best::str{"hello, "},
-                  best::row{0, format_spec{}}.forward(),
+                  best::args(0, format_spec{}),
                   best::str("!"),
               }});
 
-  t.expect_eq(parse("hello, {}, {}, {}!"),
-              Ast{{
-                  best::str{"hello, "},
-                  best::row{0, format_spec{}}.forward(),
-                  best::str(", "),
-                  best::row{1, format_spec{}}.forward(),
-                  best::str(", "),
-                  best::row{2, format_spec{}}.forward(),
-                  best::str("!"),
-              }});
+  t.expect_eq(parse("hello, {}, {}, {}!"), Ast{{
+                                               best::str{"hello, "},
+                                               best::args(0, format_spec{}),
+                                               best::str(", "),
+                                               best::args(1, format_spec{}),
+                                               best::str(", "),
+                                               best::args(2, format_spec{}),
+                                               best::str("!"),
+                                           }});
 
-  t.expect_eq(parse("hello, {1}, {}, {}!"),
-              Ast{{
-                  best::str{"hello, "},
-                  best::row{1, format_spec{}}.forward(),
-                  best::str(", "),
-                  best::row{0, format_spec{}}.forward(),
-                  best::str(", "),
-                  best::row{1, format_spec{}}.forward(),
-                  best::str("!"),
-              }});
+  t.expect_eq(parse("hello, {1}, {}, {}!"), Ast{{
+                                                best::str{"hello, "},
+                                                best::args(1, format_spec{}),
+                                                best::str(", "),
+                                                best::args(0, format_spec{}),
+                                                best::str(", "),
+                                                best::args(1, format_spec{}),
+                                                best::str("!"),
+                                            }});
 
   t.expect_eq(parse("align: {:x<1} {5:0<1} {:<1} {:<<1} {:x^1} {5:0^1} {:^1} "
                     "{:^^1} {:x>1} "
                     "{5:0>1} {:>1} {:>>1}"),  //
               Ast{{
                   best::str{"align: "},
-                  best::row{0, format_spec{.alignment = format_spec::Left,
-                                           .fill = 'x',
-                                           .width = 1}}
-                      .forward(),
+                  best::args(0, format_spec{.alignment = format_spec::Left,
+                                            .fill = 'x',
+                                            .width = 1}),
                   best::str(" "),
-                  best::row{5, format_spec{.alignment = format_spec::Left,
-                                           .fill = '0',
-                                           .width = 1}}
-                      .forward(),
+                  best::args(5, format_spec{.alignment = format_spec::Left,
+                                            .fill = '0',
+                                            .width = 1}),
                   best::str(" "),
-                  best::row{1, format_spec{.alignment = format_spec::Left,
-                                           .fill = ' ',
-                                           .width = 1}}
-                      .forward(),
+                  best::args(1, format_spec{.alignment = format_spec::Left,
+                                            .fill = ' ',
+                                            .width = 1}),
                   best::str(" "),
-                  best::row{2, format_spec{.alignment = format_spec::Left,
-                                           .fill = '<',
-                                           .width = 1}}
-                      .forward(),
+                  best::args(2, format_spec{.alignment = format_spec::Left,
+                                            .fill = '<',
+                                            .width = 1}),
                   best::str(" "),
-                  best::row{3, format_spec{.alignment = format_spec::Center,
-                                           .fill = 'x',
-                                           .width = 1}}
-                      .forward(),
+                  best::args(3, format_spec{.alignment = format_spec::Center,
+                                            .fill = 'x',
+                                            .width = 1}),
                   best::str(" "),
-                  best::row{5, format_spec{.alignment = format_spec::Center,
-                                           .fill = '0',
-                                           .width = 1}}
-                      .forward(),
+                  best::args(5, format_spec{.alignment = format_spec::Center,
+                                            .fill = '0',
+                                            .width = 1}),
                   best::str(" "),
-                  best::row{4, format_spec{.alignment = format_spec::Center,
-                                           .fill = ' ',
-                                           .width = 1}}
-                      .forward(),
+                  best::args(4, format_spec{.alignment = format_spec::Center,
+                                            .fill = ' ',
+                                            .width = 1}),
                   best::str(" "),
-                  best::row{5, format_spec{.alignment = format_spec::Center,
-                                           .fill = '^',
-                                           .width = 1}}
-                      .forward(),
+                  best::args(5, format_spec{.alignment = format_spec::Center,
+                                            .fill = '^',
+                                            .width = 1}),
                   best::str(" "),
-                  best::row{6, format_spec{.alignment = format_spec::Right,
-                                           .fill = 'x',
-                                           .width = 1}}
-                      .forward(),
+                  best::args(6, format_spec{.alignment = format_spec::Right,
+                                            .fill = 'x',
+                                            .width = 1}),
                   best::str(" "),
-                  best::row{5, format_spec{.alignment = format_spec::Right,
-                                           .fill = '0',
-                                           .width = 1}}
-                      .forward(),
+                  best::args(5, format_spec{.alignment = format_spec::Right,
+                                            .fill = '0',
+                                            .width = 1}),
                   best::str(" "),
-                  best::row{7, format_spec{.alignment = format_spec::Right,
-                                           .fill = ' ',
-                                           .width = 1}}
-                      .forward(),
+                  best::args(7, format_spec{.alignment = format_spec::Right,
+                                            .fill = ' ',
+                                            .width = 1}),
                   best::str(" "),
-                  best::row{8, format_spec{.alignment = format_spec::Right,
-                                           .fill = '>',
-                                           .width = 1}}
-                      .forward(),
+                  best::args(8, format_spec{.alignment = format_spec::Right,
+                                            .fill = '>',
+                                            .width = 1}),
               }});
 
-  t.expect_eq(
-      parse("flags: {:#} {:?} {:#?}"),
-      Ast{{
-          best::str{"flags: "},
-          best::row{0, format_spec{.alt = true}}.forward(),
-          best::str(" "),
-          best::row{1, format_spec{.debug = true}}.forward(),
-          best::str(" "),
-          best::row{2, format_spec{.alt = true, .debug = true}}.forward(),
-      }});
+  t.expect_eq(parse("flags: {:#} {:?} {:#?}"),
+              Ast{{
+                  best::str{"flags: "},
+                  best::args(0, format_spec{.alt = true}),
+                  best::str(" "),
+                  best::args(1, format_spec{.debug = true}),
+                  best::str(" "),
+                  best::args(2, format_spec{.alt = true, .debug = true}),
+              }});
 
   t.expect_eq(
       parse("widths: {:5} {:05} {:<5}"),
       Ast{{
           best::str{"widths: "},
-          best::row{0, format_spec{.width = 5}}.forward(),
+          best::args(0, format_spec{.width = 5}),
           best::str(" "),
-          best::row{1, format_spec{.sign_aware_padding = true, .width = 5}}
-              .forward(),
+          best::args(1, format_spec{.sign_aware_padding = true, .width = 5}),
           best::str(" "),
-          best::row{2, format_spec{.alignment = format_spec::Left, .width = 5}}
-              .forward(),
+          best::args(2,
+                     format_spec{.alignment = format_spec::Left, .width = 5}),
       }});
+
+  t.expect_eq(parse("precs: {:.2} {:5.2} {:05.2}"),
+              Ast{{
+                  best::str{"precs: "},
+                  best::args(0, format_spec{.prec = 2}),
+                  best::str(" "),
+                  best::args(1, format_spec{.width = 5, .prec = 2}),
+                  best::str(" "),
+                  best::args(2, format_spec{.sign_aware_padding = true,
+                                            .width = 5,
+                                            .prec = 2}),
+              }});
 
   t.expect_eq(
-      parse("precs: {:.2} {:5.2} {:05.2}"),
+      parse("methods: {:x} {:o} {:A} {:x?}"),
       Ast{{
-          best::str{"precs: "},
-          best::row{0, format_spec{.prec = 2}}.forward(),
+          best::str{"methods: "},
+          best::args(0, format_spec{.method = rune('x')}),
           best::str(" "),
-          best::row{1, format_spec{.width = 5, .prec = 2}}.forward(),
+          best::args(1, format_spec{.method = rune('o')}),
           best::str(" "),
-          best::row{
-              2, format_spec{.sign_aware_padding = true, .width = 5, .prec = 2}}
-              .forward(),
+          best::args(2, format_spec{.method = rune('A')}),
+          best::str(" "),
+          best::args(3, format_spec{.debug = true, .method = rune('x')}),
       }});
-
-  t.expect_eq(parse("methods: {:x} {:o} {:A} {:x?}"),
-              Ast{{
-                  best::str{"methods: "},
-                  best::row{0, format_spec{.method = rune('x')}}.forward(),
-                  best::str(" "),
-                  best::row{1, format_spec{.method = rune('o')}}.forward(),
-                  best::str(" "),
-                  best::row{2, format_spec{.method = rune('A')}}.forward(),
-                  best::str(" "),
-                  best::row{3, format_spec{.debug = true, .method = rune('x')}}
-                      .forward(),
-              }});
 };
 }  // namespace best::format_internal::parser_test


### PR DESCRIPTION
This change adds a large set of new operations to `best::tlist` and `best::row` to make slicing and dicing them in generic code simpler. Among other things, `best::row(1, 2) + best::row(3, 4)` works now!

This change also renames `best::row_forward` to `best::args`.