### PR TITLE
Several "riders" from a larger change

### DIFF
--- a/best/base/BUILD
+++ b/best/base/BUILD
@@ -36,6 +36,7 @@ cc_library(
   hdrs = ["guard.h"],
   deps = [
     ":tags",
+    "//best/meta:taxonomy",
   ]
 )
 

--- a/best/base/BUILD
+++ b/best/base/BUILD
@@ -4,14 +4,19 @@ cc_library(
   name = "fwd",
   hdrs = ["fwd.h"],
   deps = [
+    ":tags",
     "//best/meta:taxonomy",
-    "//best/meta:tags",
   ]
 )
 
 cc_library(
   name = "port",
   hdrs = ["port.h"],
+)
+
+cc_library(
+  name = "tags",
+  hdrs = ["tags.h"],
 )
 
 cc_library(
@@ -24,6 +29,14 @@ cc_library(
   name = "unsafe",
   hdrs = ["unsafe.h"],
   deps = [":port"],
+)
+
+cc_library(
+  name = "guard",
+  hdrs = ["guard.h"],
+  deps = [
+    ":tags",
+  ]
 )
 
 cc_library(

--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -98,6 +98,9 @@ class track_location;
 // best/meta/empty.h
 struct empty;
 
+// best/meta/names.h
+class type_names;
+
 // best/meta/reflect.h
 template <typename>
 class mirror;

--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -24,7 +24,7 @@
 
 #include <cstdint>
 
-#include "best/meta/tags.h"
+#include "best/base/tags.h"
 #include "best/meta/taxonomy.h"
 
 //! Forward declarations of all types in best that can be forward-declared.

--- a/best/base/guard.h
+++ b/best/base/guard.h
@@ -17,10 +17,10 @@
 
 \* ////////////////////////////////////////////////////////////////////////// */
 
-#ifndef BEST_META_GUARD_H_
-#define BEST_META_GUARD_H_
+#ifndef BEST_BASE_GUARD_H_
+#define BEST_BASE_GUARD_H_
 
-#include "best/meta/tags.h"
+#include "best/base/tags.h"
 
 //! A middling approximation of Rust's `?` operator.
 //!
@@ -82,4 +82,4 @@ template <typename R>
 impl(R&&) -> impl<R&&>;
 }  // namespace guard_internal
 }  // namespace best
-#endif  // BEST_META_GUARD_H_
+#endif  // BEST_BASE_GUARD_H_

--- a/best/base/guard.h
+++ b/best/base/guard.h
@@ -21,6 +21,7 @@
 #define BEST_BASE_GUARD_H_
 
 #include "best/base/tags.h"
+#include "best/meta/taxonomy.h"
 
 //! A middling approximation of Rust's `?` operator.
 //!

--- a/best/base/tags.h
+++ b/best/base/tags.h
@@ -17,8 +17,8 @@
 
 \* ////////////////////////////////////////////////////////////////////////// */
 
-#ifndef BEST_META_TAGS_H_
-#define BEST_META_TAGS_H_
+#ifndef BEST_BASE_TAGS_H_
+#define BEST_BASE_TAGS_H_
 
 #include <stddef.h>
 
@@ -76,4 +76,4 @@ struct ctad_guard;
 }  // namespace tags_internal_do_not_use
 }  // namespace best
 
-#endif  // BEST_META_TAGS_H_
+#endif  // BEST_BASE_TAGS_H_

--- a/best/container/BUILD
+++ b/best/container/BUILD
@@ -9,7 +9,7 @@ cc_library(
   deps = [
     ":pun",
     "//best/base:port",
-    "//best/meta:tags",
+    "//best/base:tags",
     "//best/log/internal:crash",
   ],
 )
@@ -75,7 +75,7 @@ cc_library(
     ":object",
     "//best/base:port",
     "//best/memory:layout",
-    "//best/meta:tags",
+    "//best/base:tags",
     "//best/meta:init",
   ],
 )
@@ -123,7 +123,7 @@ cc_library(
   deps = [
     ":object",
     "//best/base:port",
-    "//best/meta:tags",
+    "//best/base:tags",
   ],
 )
 
@@ -175,7 +175,7 @@ cc_library(
     "//best/memory:bytes",
     "//best/memory:layout",
     "//best/meta:init",
-    "//best/meta:tags",
+    "//best/base:tags",
   ],
 )
 

--- a/best/container/choice.h
+++ b/best/container/choice.h
@@ -23,11 +23,11 @@
 #include <initializer_list>
 
 #include "best/base/ord.h"
+#include "best/base/tags.h"
 #include "best/container/internal/choice.h"
 #include "best/log/internal/crash.h"
 #include "best/log/location.h"
 #include "best/meta/init.h"
-#include "best/meta/tags.h"
 
 //! A sum type, like `std::variant`.
 //!

--- a/best/container/internal/choice.h
+++ b/best/container/internal/choice.h
@@ -23,13 +23,13 @@
 #include <array>
 #include <cstddef>
 
+#include "best/base/tags.h"
 #include "best/container/internal/pun.h"
 #include "best/container/object.h"
 #include "best/container/pun.h"
 #include "best/math/int.h"
 #include "best/meta/init.h"
 #include "best/meta/internal/init.h"
-#include "best/meta/tags.h"
 
 //! Internal implementation of best::choice.
 

--- a/best/container/internal/pun.h
+++ b/best/container/internal/pun.h
@@ -23,8 +23,8 @@
 #include <type_traits>
 
 #include "best/base/port.h"
+#include "best/base/tags.h"
 #include "best/container/object.h"
-#include "best/meta/tags.h"
 #include "best/meta/tlist.h"
 
 //! Internal implementation of best::pun.

--- a/best/container/internal/row.h
+++ b/best/container/internal/row.h
@@ -213,7 +213,7 @@ constexpr auto splice(auto&& row, auto those_types, auto&& those) {
 
 // See tlist_internal::gather_impl() and tlist_internal::scatter_impl().
 template <size_t... i>
-auto gather(auto&& row)
+constexpr auto gather(auto&& row)
   requires((i < best::as_auto<decltype(row)>::size()) && ...)
 {
   using Out =
@@ -221,7 +221,7 @@ auto gather(auto&& row)
   return Out{BEST_FWD(row)[best::index<i>]...};
 }
 template <size_t... i>
-auto scatter(auto&& row, auto those_types, auto&& those)
+constexpr auto scatter(auto&& row, auto those_types, auto&& those)
   requires((i < best::as_auto<decltype(row)>::size()) && ...) &&
           (sizeof...(i) <= best::as_auto<decltype(those)>::size()) &&
           (sizeof...(i) <= best::as_auto<decltype(those_types)>::size()) &&

--- a/best/container/object.h
+++ b/best/container/object.h
@@ -27,9 +27,9 @@
 
 #include "best/base/ord.h"
 #include "best/base/port.h"
+#include "best/base/tags.h"
 #include "best/meta/empty.h"
 #include "best/meta/init.h"
-#include "best/meta/tags.h"
 #include "best/meta/traits.h"
 
 //! Objectification: turn any C++ type into a something you can use as a class

--- a/best/container/option.h
+++ b/best/container/option.h
@@ -753,7 +753,7 @@ class option final {
 
   constexpr void check_ok(best::location loc = best::here) const {
     if (best::unlikely(is_empty())) {
-      crash_internal::crash({"attempted access of empty best::option", loc});
+      crash_internal::crash({"unwrapped a best::none", loc});
     }
   }
 

--- a/best/container/option.h
+++ b/best/container/option.h
@@ -23,12 +23,12 @@
 #include <initializer_list>
 
 #include "best/base/fwd.h"
+#include "best/base/tags.h"
 #include "best/container/choice.h"
 #include "best/log/internal/crash.h"
 #include "best/log/location.h"
 #include "best/meta/init.h"
 #include "best/meta/internal/init.h"
-#include "best/meta/tags.h"
 
 //! An optional type, like `std::optional`.
 //!

--- a/best/container/result.h
+++ b/best/container/result.h
@@ -20,9 +20,9 @@
 #ifndef BEST_CONTAINER_RESULT_H_
 #define BEST_CONTAINER_RESULT_H_
 
+#include "best/base/tags.h"
 #include "best/container/choice.h"
 #include "best/container/row.h"
-#include "best/meta/tags.h"
 
 //! A result type, like `std::expected`.
 //!

--- a/best/container/row.h
+++ b/best/container/row.h
@@ -22,11 +22,11 @@
 
 #include "best/base/fwd.h"
 #include "best/base/ord.h"
+#include "best/base/tags.h"
 #include "best/container/internal/row.h"
 #include "best/container/object.h"
 #include "best/meta/empty.h"
 #include "best/meta/init.h"
-#include "best/meta/tags.h"
 #include "best/meta/taxonomy.h"
 #include "best/meta/tlist.h"
 

--- a/best/container/row_test.cc
+++ b/best/container/row_test.cc
@@ -62,6 +62,14 @@ best::test ToString = [](auto& t) {
   t.expect_eq(best::format("{:?}", x3), "(1, void, 3)");
 };
 
+best::test Each = [](auto& t) {
+  best::row x0 = {1, 2};
+
+  int sum = 0;
+  x0.each([&](int x) { sum += x; });
+  t.expect_eq(sum, 3);
+};
+
 struct Tag {
   using BestRowKey = Tag;
   bool operator==(const Tag&) const = default;

--- a/best/container/span.h
+++ b/best/container/span.h
@@ -717,6 +717,11 @@ class span<T, n>::iter_impl final {
 
   constexpr size_t count() && { return end_ - start_; }
 
+  constexpr best::option<T&> last() && {
+    if (start_ == end_) return best::none;
+    return end_[-1];
+  }
+
   T* start_;
   T* end_;
 };

--- a/best/container/vec.h
+++ b/best/container/vec.h
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <initializer_list>
 
+#include "best/base/tags.h"
 #include "best/container/object.h"
 #include "best/container/option.h"
 #include "best/container/span.h"
@@ -33,7 +34,6 @@
 #include "best/memory/allocator.h"
 #include "best/memory/layout.h"
 #include "best/meta/init.h"
-#include "best/meta/tags.h"
 
 //! Dynamically sized sequences.
 //!

--- a/best/container/vec.h
+++ b/best/container/vec.h
@@ -678,6 +678,11 @@ class vec final {
 
 template <typename T>
 vec(std::initializer_list<T>) -> vec<T>;
+template <contiguous Range>
+vec(Range) -> vec<best::as_auto<typename best::data_type<Range>>>;
+template <is_iter Iter>
+  requires(!contiguous<Iter>)
+vec(Iter) -> vec<best::as_auto<typename best::iter_type<Iter>>>;
 }  // namespace best
 
 /* ////////////////////////////////////////////////////////////////////////// *\

--- a/best/func/tap.h
+++ b/best/func/tap.h
@@ -20,8 +20,8 @@
 #ifndef BEST_FUNC_TAP_H_
 #define BEST_FUNC_TAP_H_
 
+#include "best/base/tags.h"
 #include "best/func/call.h"
-#include "best/meta/tags.h"
 #include "best/meta/taxonomy.h"
 
 //! Taps, `best`'s "functional pipeline" syntax.

--- a/best/iter/bounds_test.cc
+++ b/best/iter/bounds_test.cc
@@ -86,32 +86,30 @@ best::test Debug = [](auto& t) {
 };
 
 best::test Iter = [](auto& t) {
-  best::vec<size_t> xs;
-  for (size_t i : best::bounds{.start = 5, .end = 11}) {
-    xs.push(i);
-  }
-  t.expect_eq(xs, {5, 6, 7, 8, 9, 10});
+  best::bounds b = {.start = 5, .end = 11};
+  t.expect_eq(best::vec(b.iter()), {5, 6, 7, 8, 9, 10});
+  t.expect_eq(b.iter().count(), 6);
+  t.expect_eq(b.iter().last(), 10);
 
-  xs.clear();
-  for (size_t i : best::bounds{.start = 5, .including_end = 11}) {
-    xs.push(i);
-  }
-  t.expect_eq(xs, {5, 6, 7, 8, 9, 10, 11});
+  b = {.start = 5, .including_end = 11};
+  t.expect_eq(best::vec(b.iter()), {5, 6, 7, 8, 9, 10, 11});
+  t.expect_eq(b.iter().count(), 7);
+  t.expect_eq(b.iter().last(), 11);
 
-  xs.clear();
-  for (size_t i : best::bounds{.start = best::max_of<size_t> - 1,
-                  .including_end = best::max_of<size_t>}) {
-    xs.push(i);
-  }
-  t.expect_eq(xs, {best::max_of<size_t> - 1, best::max_of<size_t>});
+  b = {
+      .start = best::max_of<size_t> - 1,
+      .including_end = best::max_of<size_t>,
+  };
+  t.expect_eq(best::vec(b.iter()),
+              {best::max_of<size_t> - 1, best::max_of<size_t>});
+  t.expect_eq(b.iter().count(), 2);
+  t.expect_eq(b.iter().last(), best::max_of<size_t>);
 
-  best::vec<uint8_t> ys;
-  for (auto i : best::int_range{.start = uint8_t(0)}) {
-    ys.push(i);
-  }
-
-  best::vec<size_t> zs(best::bounds{.count = 256}.iter());
-  t.expect_eq(ys, zs);
+  best::int_range i = {.start = uint8_t(0)};
+  t.expect_eq(best::vec(i.iter()),
+              best::vec(best::bounds{.count = 256}.iter()));
+  t.expect_eq(i.iter().count(), 256);
+  t.expect_eq(i.iter().last(), 255);
 };
 
 // TODO: Once we have death tests, test the check-fail messages.

--- a/best/iter/iter.h
+++ b/best/iter/iter.h
@@ -25,9 +25,9 @@
 //! C++ iterators are bad. Ranges are not much better, ergonomically speaking.
 //! Rust iterators, however, are pretty great. Hence, we've done our best to
 
+#include "best/base/guard.h"
 #include "best/container/option.h"
 #include "best/func/call.h"
-#include "best/meta/guard.h"
 #include "best/meta/init.h"
 #include "best/meta/taxonomy.h"
 

--- a/best/iter/iter.h
+++ b/best/iter/iter.h
@@ -121,7 +121,7 @@ class iter final {
   /// requirement that it continue to yield `best::none` forever
   constexpr best::option<item> next() { return impl_.next(); }
 
-#define BEST_ITER_FWD(func_)                           \
+#define BEST_ITER_FWD(func_)                            \
   if constexpr (requires { BEST_MOVE(impl_).func_(); }) \
     return BEST_MOVE(impl_).func_();
 

--- a/best/math/BUILD
+++ b/best/math/BUILD
@@ -27,7 +27,7 @@ cc_library(
     ":int",
     ":overflow",
     "//best/container:result",
-    "//best/meta:guard",
+    "//best/base:guard",
     "//best/text:str",
   ]
 )

--- a/best/math/conv.h
+++ b/best/math/conv.h
@@ -20,9 +20,9 @@
 #ifndef BEST_MATH_CONV_H_
 #define BEST_MATH_CONV_H_
 
+#include "best/base/guard.h"
 #include "best/math/int.h"
 #include "best/math/overflow.h"
-#include "best/meta/guard.h"
 #include "best/text/str.h"
 
 //! Number-string conversion primitives.

--- a/best/meta/BUILD
+++ b/best/meta/BUILD
@@ -44,9 +44,8 @@ cc_library(
     "internal/init.h",
   ],
   deps = [
-    ":bit_enum",
-    ":tags",
     ":taxonomy",
+    "//best/base:tags",
   ]
 )
 

--- a/best/meta/BUILD
+++ b/best/meta/BUILD
@@ -1,11 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-  name = "tags",
-  hdrs = ["tags.h"],
-)
-
-cc_library(
   name = "bit_enum",
   hdrs = ["bit_enum.h"],
 )
@@ -39,14 +34,6 @@ cc_library(
   ],
   deps = [
     "//best/base:hint",
-  ]
-)
-
-cc_library(
-  name = "guard",
-  hdrs = ["guard.h"],
-  deps = [
-    ":tlist",
   ]
 )
 

--- a/best/meta/empty.h
+++ b/best/meta/empty.h
@@ -24,9 +24,9 @@
 
 #include <type_traits>
 
+#include "best/base/tags.h"
 #include "best/meta/init.h"
 #include "best/meta/internal/init.h"
-#include "best/meta/tags.h"
 #include "best/meta/taxonomy.h"
 #include "best/meta/traits.h"
 

--- a/best/meta/internal/reflect.h
+++ b/best/meta/internal/reflect.h
@@ -308,17 +308,16 @@ class tdesc final {
   static constexpr auto infer_struct()
     requires best::is_struct<T>
   {
-    auto fields = best::indices<total_fields<T>>.apply(
-        [&]<size_t... i>(best::index_t<i>...) {
-          return best::row{fdesc(
-              best::vals<eyepatch(
-                  best::addr(reflect_internal::bind<i>(materialize<T>())))>,
-              best::types<T>,
-              [](auto&& v) -> decltype(auto) {
-                return reflect_internal::bind<i>(BEST_FWD(v));
-              },
-              best::row())...};
-        });
+    auto fields = best::indices<total_fields<T>>.apply([&]<size_t... i> {
+      return best::row{fdesc(
+          best::vals<eyepatch(
+              best::addr(reflect_internal::bind<i>(materialize<T>())))>,
+          best::types<T>,
+          [](auto&& v) -> decltype(auto) {
+            return reflect_internal::bind<i>(BEST_FWD(v));
+          },
+          best::row())...};
+    });
     return reflect_internal::tdesc(best::types<T>, fields, best::row());
   }
 
@@ -329,26 +328,24 @@ class tdesc final {
   {
     BEST_PUSH_GCC_DIAGNOSTIC()
     BEST_IGNORE_GCC_DIAGNOSTIC("-Wenum-constexpr-conversion")
-    constexpr auto ok =
-        best::indices<count>.apply([]<size_t... i>(best::index_t<i>...) {
-          constexpr size_t ok_count =
-              (0 + ... + best::value_name<T(start + i)>.has_value());
+    constexpr auto ok = best::indices<count>.apply([]<size_t... i> {
+      constexpr size_t ok_count =
+          (0 + ... + best::value_name<T(start + i)>.has_value());
 
-          std::array<T, ok_count> ok = {};
-          size_t idx = 0;
+      std::array<T, ok_count> ok = {};
+      size_t idx = 0;
 
-          ((best::value_name<T(start + i)>.has_value()
-                ? void(ok[idx++] = T(start + i))
-                : void()),
-           ...);
-          return ok;
-        });
+      ((best::value_name<T(start + i)>.has_value()
+            ? void(ok[idx++] = T(start + i))
+            : void()),
+       ...);
+      return ok;
+    });
     BEST_POP_GCC_DIAGNOSTIC()
 
-    auto values =
-        best::indices<ok.size()>.apply([&]<size_t... i>(best::index_t<i>...) {
-          return best::row{vdesc{best::vals<ok[i]>, best::row()}...};
-        });
+    auto values = best::indices<ok.size()>.apply([&]<size_t... i> {
+      return best::row{vdesc{best::vals<ok[i]>, best::row()}...};
+    });
     return reflect_internal::tdesc(best::types<T>, values, best::row());
   }
 

--- a/best/meta/internal/reflect.h
+++ b/best/meta/internal/reflect.h
@@ -158,10 +158,10 @@ constexpr decltype(auto) bind(auto&& val, auto&& cb) {
 /// Binds the `n`th field of `struct`.
 template <size_t n>
 constexpr decltype(auto) bind(auto&& val) {
-  return best::indices<n>.apply([&]<typename... I>() -> decltype(auto) {
+  return best::indices<n>.apply([&](auto... i) -> decltype(auto) {
     return reflect_internal::bind(
         BEST_FWD(val),
-        [&](best::dependent<discard, I>..., auto&& the_one,
+        [&](best::dependent<discard, decltype(i)>..., auto&& the_one,
             auto&&... rest) -> decltype(auto) {
           // Structured bindings' type does not preserve value category
           // correctly, so we need to adjust its type to match the value
@@ -308,16 +308,17 @@ class tdesc final {
   static constexpr auto infer_struct()
     requires best::is_struct<T>
   {
-    auto fields = best::indices<total_fields<T>>.apply([&]<typename... I>() {
-      return best::row{fdesc(
-          best::vals<eyepatch(
-              best::addr(reflect_internal::bind<I::value>(materialize<T>())))>,
-          best::types<T>,
-          [](auto&& v) -> decltype(auto) {
-            return reflect_internal::bind<I::value>(BEST_FWD(v));
-          },
-          best::row())...};
-    });
+    auto fields = best::indices<total_fields<T>>.apply(
+        [&]<size_t... i>(best::index_t<i>...) {
+          return best::row{fdesc(
+              best::vals<eyepatch(
+                  best::addr(reflect_internal::bind<i>(materialize<T>())))>,
+              best::types<T>,
+              [](auto&& v) -> decltype(auto) {
+                return reflect_internal::bind<i>(BEST_FWD(v));
+              },
+              best::row())...};
+        });
     return reflect_internal::tdesc(best::types<T>, fields, best::row());
   }
 
@@ -328,27 +329,26 @@ class tdesc final {
   {
     BEST_PUSH_GCC_DIAGNOSTIC()
     BEST_IGNORE_GCC_DIAGNOSTIC("-Wenum-constexpr-conversion")
-    constexpr auto ok = best::indices<count>.apply([]<typename... I> {
-      constexpr size_t ok_count =
-          (0 + ... + best::value_name<T(start + I::value)>.has_value());
+    constexpr auto ok =
+        best::indices<count>.apply([]<size_t... i>(best::index_t<i>...) {
+          constexpr size_t ok_count =
+              (0 + ... + best::value_name<T(start + i)>.has_value());
 
-      std::array<T, ok_count> ok = {};
-      size_t idx = 0;
+          std::array<T, ok_count> ok = {};
+          size_t idx = 0;
 
-      ((best::value_name<T(start + I::value)>.has_value()
-            ? void(ok[idx++] = T(start + I::value))
-            : void()),
-       ...);
-      return ok;
-    });
+          ((best::value_name<T(start + i)>.has_value()
+                ? void(ok[idx++] = T(start + i))
+                : void()),
+           ...);
+          return ok;
+        });
     BEST_POP_GCC_DIAGNOSTIC()
 
-    auto values = best::indices<ok.size()>.apply([&]<typename... I> {
-      return best::row{vdesc{
-          best::vals<ok[I::value]>,
-          best::row(),
-      }...};
-    });
+    auto values =
+        best::indices<ok.size()>.apply([&]<size_t... i>(best::index_t<i>...) {
+          return best::row{vdesc{best::vals<ok[i]>, best::row()}...};
+        });
     return reflect_internal::tdesc(best::types<T>, values, best::row());
   }
 

--- a/best/meta/internal/tlist.h
+++ b/best/meta/internal/tlist.h
@@ -253,16 +253,22 @@ concept uniq = (set<>{} + ... + entry<Ts>{}).value;
 // type or value arguments.
 template <typename F, typename... Elems>
 concept t_callable = (... && best::callable<F, void(), Elems>);
-
-template <typename F, typename... Elems>
-concept v_callable = sizeof...(Elems) > 0 &&
-                     (... && best::callable<F, void(Elems)>);
-
 template <typename F, typename... Elems>
 concept ts_callable = best::callable<F, void(), Elems...>;
 
 template <typename F, typename... Elems>
+concept v_callable = sizeof...(Elems) > 0 &&
+                     (... && best::callable<F, void(Elems)>);
+template <typename F, typename... Elems>
 concept vs_callable = sizeof...(Elems) > 0 && best::callable<F, void(Elems...)>;
+
+template <typename F, typename... Elems>
+concept vt_callable = sizeof...(Elems) > 0 &&
+                      (... && requires(F f) { best::call<Elems::value>(f); });
+template <typename F, typename... Elems>
+concept vts_callable =
+    sizeof...(Elems) > 0 && requires(F f) { best::call<Elems::value...>(f); };
+
 }  // namespace best::tlist_internal
 
 #endif  // BEST_META_INTERNAL_TLIST_H_

--- a/best/meta/internal/tlist.h
+++ b/best/meta/internal/tlist.h
@@ -256,19 +256,13 @@ concept t_callable = (... && best::callable<F, void(), Elems>);
 
 template <typename F, typename... Elems>
 concept v_callable = sizeof...(Elems) > 0 &&
-                     (... && requires(F f) { best::call(f, Elems::value); });
+                     (... && best::callable<F, void(Elems)>);
 
 template <typename F, typename... Elems>
 concept ts_callable = best::callable<F, void(), Elems...>;
 
 template <typename F, typename... Elems>
-concept vs_callable =
-    sizeof...(Elems) > 0 && requires(F f) { best::call(f, Elems{}...); };
-
-template <typename F, typename... Elems>
-concept tvs_callable =
-    sizeof...(Elems) > 0 && requires(F f) { best::call(f, Elems::value...); };
-
+concept vs_callable = sizeof...(Elems) > 0 && best::callable<F, void(Elems...)>;
 }  // namespace best::tlist_internal
 
 #endif  // BEST_META_INTERNAL_TLIST_H_

--- a/best/meta/reflect.h
+++ b/best/meta/reflect.h
@@ -444,30 +444,26 @@ constexpr auto best::mirror<T>::infer() const
 template <auto& desc_>
 constexpr decltype(auto) reflected_type<desc_>::apply(auto&& cb) const {
   if constexpr (best::is_struct<reflected>) {
-    return best::indices<desc_.items_.types.size()>.apply(
-        [&]<size_t... i>(best::index_t<i>...) {
-          return best::call(BEST_FWD(cb), best::reflected_field<item<i>>{}...);
-        });
+    return best::indices<desc_.items_.types.size()>.apply([&]<size_t... i> {
+      return best::call(BEST_FWD(cb), best::reflected_field<item<i>>{}...);
+    });
   } else {
-    return best::indices<desc_.items_.types.size()>.apply(
-        [&]<size_t... i>(best::index_t<i>...) {
-          return best::call(BEST_FWD(cb), best::reflected_value<item<i>>{}...);
-        });
+    return best::indices<desc_.items_.types.size()>.apply([&]<size_t... i> {
+      return best::call(BEST_FWD(cb), best::reflected_value<item<i>>{}...);
+    });
   }
 }
 
 template <auto& desc_>
 constexpr void reflected_type<desc_>::each(auto&& cb) const {
   if constexpr (best::is_struct<reflected>) {
-    return best::indices<desc_.items_.types.size()>.each(
-        [&]<size_t i>(best::index_t<i>) {
-          best::call(BEST_FWD(cb), best::reflected_field<item<i>>{});
-        });
+    return best::indices<desc_.items_.types.size()>.each([&]<size_t i> {
+      best::call(BEST_FWD(cb), best::reflected_field<item<i>>{});
+    });
   } else {
-    return best::indices<desc_.items_.types.size()>.each(
-        [&]<size_t i>(best::index_t<i>) {
-          best::call(BEST_FWD(cb), best::reflected_value<item<i>>{});
-        });
+    return best::indices<desc_.items_.types.size()>.each([&]<size_t i> {
+      best::call(BEST_FWD(cb), best::reflected_value<item<i>>{});
+    });
   }
 }
 

--- a/best/meta/taxonomy.h
+++ b/best/meta/taxonomy.h
@@ -117,6 +117,30 @@ concept is_tame_func = is_func<T> && requires { (T*){}; };
 template <typename T>
 concept is_abominable = is_func<T> && !requires { (T*){}; };
 
+/// # `best::is_const_func`
+///
+/// Whether this is a `const`-qualified abominable function.
+template <typename T>
+concept is_const_func = abominable_internal::tame<T>::c;
+
+/// # `best::is_lref_func`
+///
+/// Whether this is a `&`-qualified abominable function.
+template <typename T>
+concept is_lref_func = abominable_internal::tame<T>::l;
+
+/// # `best::is_rref_func`
+///
+/// Whether this is a `&&`-qualified abominable function.
+template <typename T>
+concept is_rref_func = abominable_internal::tame<T>::r;
+
+/// # `best::is_ref_func`
+///
+/// Whether this is a `&`- or `&&-qualified abominable function.
+template <typename T>
+concept is_ref_func = is_lref_func<T> || is_rref_func<T>;
+
 /// # `best::tame<T>`
 ///
 /// If `T` is an abominable function, returns its "tame" counterpart. Otherwise,

--- a/best/meta/taxonomy.h
+++ b/best/meta/taxonomy.h
@@ -117,30 +117,6 @@ concept is_tame_func = is_func<T> && requires { (T*){}; };
 template <typename T>
 concept is_abominable = is_func<T> && !requires { (T*){}; };
 
-/// # `best::is_const_func`
-///
-/// Whether this is a `const`-qualified abominable function.
-template <typename T>
-concept is_const_func = abominable_internal::tame<T>::c;
-
-/// # `best::is_lref_func`
-///
-/// Whether this is a `&`-qualified abominable function.
-template <typename T>
-concept is_lref_func = abominable_internal::tame<T>::l;
-
-/// # `best::is_rref_func`
-///
-/// Whether this is a `&&`-qualified abominable function.
-template <typename T>
-concept is_rref_func = abominable_internal::tame<T>::r;
-
-/// # `best::is_ref_func`
-///
-/// Whether this is a `&`- or `&&-qualified abominable function.
-template <typename T>
-concept is_ref_func = is_lref_func<T> || is_rref_func<T>;
-
 /// # `best::tame<T>`
 ///
 /// If `T` is an abominable function, returns its "tame" counterpart. Otherwise,

--- a/best/meta/tlist.h
+++ b/best/meta/tlist.h
@@ -381,7 +381,11 @@ class tlist final {
   }
   template <tlist_internal::v_callable<Elems...> auto cb>
   static constexpr decltype(auto) map() {
-    return best::vals<best::call(cb, Elems::value)...>;
+    return best::vals<best::call(cb, Elems{})...>;
+  }
+  template <tlist_internal::vt_callable<Elems...> auto cb>
+  static constexpr decltype(auto) map() {
+    return best::vals<best::call<Elems::value>(cb)...>;
   }
   template <template <typename> typename Trait>
   static constexpr decltype(auto) map();
@@ -398,6 +402,9 @@ class tlist final {
   static constexpr void each(tlist_internal::v_callable<Elems...> auto&& cb) {
     (best::call(BEST_FWD(cb), Elems{}), ...);
   }
+  static constexpr void each(tlist_internal::vt_callable<Elems...> auto&& cb) {
+    (best::call<Elems::value>(BEST_FWD(cb)), ...);
+  }
 
   /// # `tlist::apply()`
   ///
@@ -410,6 +417,10 @@ class tlist final {
   static constexpr decltype(auto) apply(
       tlist_internal::vs_callable<Elems...> auto&& cb) {
     return best::call(BEST_FWD(cb), Elems{}...);
+  };
+  static constexpr decltype(auto) apply(
+      tlist_internal::vts_callable<Elems...> auto&& cb) {
+    return best::call<Elems::value...>(BEST_FWD(cb));
   };
   template <template <typename...> typename Trait>
   static constexpr Trait<Elems...> apply() {

--- a/best/meta/tlist.h
+++ b/best/meta/tlist.h
@@ -318,7 +318,7 @@ class tlist final {
     return opt_size{};
   }
   static constexpr auto find(tlist_internal::v_callable<Elems...> auto pred) {
-    return find([&]<typename V> { return pred(V::value); });
+    return find([&]<typename V> { return best::call(pred, V{}); });
   }
   template <typename T>
   static constexpr auto find() {
@@ -331,7 +331,7 @@ class tlist final {
   static constexpr auto find(auto value)
     requires(best::equatable<decltype(value), decltype(Elems::value)> && ...)
   {
-    return find([&](auto that) { return value == that; });
+    return find([&](auto that) { return value == that.value; });
   }
 
   /// # `tlist::find_unique()`
@@ -349,7 +349,7 @@ class tlist final {
   }
   static constexpr auto find_unique(
       tlist_internal::v_callable<Elems...> auto pred) {
-    return find_unique([&]<typename V> { return pred(V::value); });
+    return find_unique([&]<typename V> { return best::call(pred, V{}); });
   }
   template <typename T>
   static constexpr auto find_unique() {
@@ -364,7 +364,7 @@ class tlist final {
   static constexpr auto find_unique(auto value)
     requires(best::equatable<decltype(value), decltype(Elems::value)> && ...)
   {
-    return find_unique([&](auto that) { return value == that; });
+    return find_unique([&](auto that) { return value == that.value; });
   }
 
   /// # `tlist::map()`
@@ -396,7 +396,7 @@ class tlist final {
     (best::call<Elems>(BEST_FWD(cb)), ...);
   }
   static constexpr void each(tlist_internal::v_callable<Elems...> auto&& cb) {
-    (best::call(BEST_FWD(cb), Elems::value), ...);
+    (best::call(BEST_FWD(cb), Elems{}), ...);
   }
 
   /// # `tlist::apply()`
@@ -409,7 +409,7 @@ class tlist final {
   }
   static constexpr decltype(auto) apply(
       tlist_internal::vs_callable<Elems...> auto&& cb) {
-    return best::call(BEST_FWD(cb), Elems::value...);
+    return best::call(BEST_FWD(cb), Elems{}...);
   };
   template <template <typename...> typename Trait>
   static constexpr Trait<Elems...> apply() {

--- a/best/meta/tlist_test.cc
+++ b/best/meta/tlist_test.cc
@@ -78,7 +78,9 @@ static_assert(
 static_assert(best::types<int*, int, void*>.find<void*>() == 2);
 static_assert(best::types<int*, int, int>.find<std::is_integral>() == 1);
 
-static_assert(best::vals<1, 2, 3>.find([](auto x) { return x % 2 == 0; }) == 1);
+static_assert(best::vals<1, 2, 3>.find([](auto x) {
+  return x.value % 2 == 0;
+}) == 1);
 static_assert(best::vals<1, 2, 3>.find(3) == 2);
 static_assert(best::vals<1, 3, 3>.find(3) == 1);
 static_assert(!best::vals<1, 2, 3>.find(4).has_value());

--- a/best/meta/traits.h
+++ b/best/meta/traits.h
@@ -76,7 +76,7 @@ using dependent = traits_internal::dependent<T, Deps...>::type;
 /// Lies to the compiler that we can materialize a `T`. This is just a shorter
 /// `std::declval()`.
 template <traits_internal::nonvoid T>
-T lie = [] {
+T&& lie = [] {
   static_assert(
       sizeof(T) == 0,
       "attempted to tell a best::lie: this value cannot be materialized");

--- a/best/text/BUILD
+++ b/best/text/BUILD
@@ -36,7 +36,7 @@ cc_library(
     ":rune",
     "//best/container:option",
     "//best/container:span",
-    "//best/meta:guard",
+    "//best/base:guard",
   ]
 )
 
@@ -52,7 +52,7 @@ cc_library(
     ":rune",
     "//best/container:option",
     "//best/container:span",
-    "//best/meta:guard",
+    "//best/base:guard",
   ]
 )
 
@@ -80,7 +80,7 @@ cc_library(
     "//best/container:option",
     "//best/container:span",
     "//best/math:conv",
-    "//best/meta:guard",
+    "//best/base:guard",
     "//best/meta:reflect",
   ]
 )

--- a/best/text/ascii.h
+++ b/best/text/ascii.h
@@ -22,9 +22,9 @@
 
 #include <cstddef>
 
+#include "best/base/guard.h"
 #include "best/container/option.h"
 #include "best/container/span.h"
-#include "best/meta/guard.h"
 #include "best/text/rune.h"
 
 //! ASCII and other 7- and 8-bit encodings. Unlike the encodings from `utf.h`,

--- a/best/text/encoding.h
+++ b/best/text/encoding.h
@@ -22,11 +22,11 @@
 
 #include <cstddef>
 
+#include "best/base/tags.h"
 #include "best/container/option.h"
 #include "best/container/result.h"
 #include "best/container/span.h"
 #include "best/meta/init.h"
-#include "best/meta/tags.h"
 
 //! Unicode encodings.
 //!

--- a/best/text/str.h
+++ b/best/text/str.h
@@ -24,10 +24,10 @@
 
 #include <cstddef>
 
+#include "best/base/guard.h"
 #include "best/container/span.h"
 #include "best/math/overflow.h"
 #include "best/memory/bytes.h"
-#include "best/meta/guard.h"
 #include "best/meta/taxonomy.h"
 #include "best/text/encoding.h"
 #include "best/text/rune.h"

--- a/best/text/str.h
+++ b/best/text/str.h
@@ -488,6 +488,7 @@ class pretext final {
   /// Creates a new string from some other string type whose encoding we can
   /// divine.
   constexpr pretext(const best::string_type auto& data)
+    requires best::same<encoding, best::encoding_type<decltype(data)>>
       : span_(data), enc_(best::encoding_of(data)) {}
 
   /// # `pretext::pretext(span)`
@@ -496,7 +497,8 @@ class pretext final {
   template <best::contiguous R>
   constexpr pretext(const R& data, encoding enc = {})
     requires best::same<best::unqual<best::data_type<R>>, code> &&
-                 (!best::string_type<R>)
+                 (!best::string_type<R> ||
+                  !best::same<encoding, best::encoding_type<decltype(data)>>)
       : span_(data), enc_(BEST_MOVE(enc)) {}
 
   /// # `pretext::from_nul()`
@@ -738,8 +740,12 @@ class pretext final {
     return span_ <=> best::span<const code>::from_nul(lit);
   }
 
-  // Make this into a best::string_type.
-  constexpr friend const encoding& BestEncoding(auto, const pretext& t) {
+  // Make this into a best::string_type. Need to make this into a funny template
+  // to avoid infinite recursion while checking
+  // best::string_type<best::pretext>.
+  constexpr friend const encoding& BestEncoding(auto, const auto& t)
+    requires best::same<decltype(t), const pretext&>
+  {
     return t.enc();
   }
 
@@ -958,7 +964,7 @@ constexpr std::array<size_t, 2> splits(best::pretext<N> haystack,
     size_t before = 0;
     while (auto next = runes.next()) {
       if (!next->ok()) return {-1, -1};
-      if (**next == first) break;
+      if (*next->ok() == first) break;
       before = haystack.size() - runes->rest().size();
     }
 
@@ -978,7 +984,7 @@ constexpr std::array<size_t, 2> splits(best::pretext<E> haystack,
   code<E> buf[E::About.max_codes_per_rune];
   auto encoded = needle.encode(buf, haystack.enc());
   return str_internal::splits(haystack,
-                              best::pretext<E>(*encoded, haystack.enc()));
+                              best::pretext<E>(*encoded.ok(), haystack.enc()));
 }
 
 template <typename E>
@@ -1228,7 +1234,7 @@ constexpr best::option<pretext<E>> pretext<E>::strip_prefix(
 
     while (auto r1 = needle.next()) {
       auto r2 = haystack.next();
-      if (r2.is_empty() || r2->err() || *r1 != **r2) return best::none;
+      if (r2.is_empty() || r2->err() || *r1 != *r2->ok()) return best::none;
     }
     return haystack->rest();
   } else {
@@ -1295,12 +1301,12 @@ pretext<E>::split_once(best::callable<bool(rune)> auto&& pred) const {
 
 template <typename E>
 constexpr auto pretext<E>::split(best::rune needle) const {
-  return split_iter<rune>(split_impl<rune>(needle), *this);
+  return split_iter<rune>(split_impl<rune>(needle, *this));
 }
 template <typename E>
 constexpr auto pretext<E>::split(const best::string_type auto& needle) const {
   pretext text = needle;
-  return split_iter<decltype(text)>(split_impl<decltype(text)>(text), *this);
+  return split_iter<decltype(text)>(split_impl<decltype(text)>(text, *this));
 }
 template <typename E>
 constexpr auto pretext<E>::split(best::callable<bool(rune)> auto&& pred) const {

--- a/best/text/utf32.h
+++ b/best/text/utf32.h
@@ -22,9 +22,9 @@
 
 #include <cstddef>
 
+#include "best/base/guard.h"
 #include "best/container/option.h"
 #include "best/container/span.h"
-#include "best/meta/guard.h"
 #include "best/text/internal/utf.h"
 #include "best/text/rune.h"
 


### PR DESCRIPTION
This change contains many small API fixes and additions that would have ridden in on a much larger change; isolating them into their own commit is mostly done to improve linear history.

Changes are approximately as follows:

- `best::result` will `best::format` the error value when forcibly unwrapped.
- Added `best::row::each()`.
- Added deduction guides for `best::vec` to allow deduction from ranges and iterators.
- Added overload to `best::call` for handling a pack of non-type template parameters (my kingdom for circle's `template auto`).
- Added `best::iter::enumerate()`.
- Added new variants of `best::tlist::apply` and `best::tlist::each` that pass the `::value` of each element as a non-type template parameter into the callback; simplifies a lot of code that was doing `best::indices<n>.apply(...)`.
- Functions on `best::formatter::block` are now chainable (that they weren't was a bug).
