### PR TITLE
Add `best::fnref` and `best::wtf`

### DIFF
--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -68,6 +68,10 @@ class pun;
 // template <typename, best::option<size_t>>
 // class span;
 
+// best/func/fnref.h
+template <typename>
+class fnref;
+
 // best/func/tap.h
 template <typename, typename>
 class tap;

--- a/best/func/BUILD
+++ b/best/func/BUILD
@@ -14,6 +14,27 @@ cc_library(
 )
 
 cc_library(
+  name = "fnref",
+  hdrs = [
+    "fnref.h",
+    "internal/fnref.h",
+  ],
+  deps = [
+    ":call",
+  ]
+)
+
+cc_test(
+  name = "fnref_test",
+  srcs = ["fnref_test.cc"],
+  linkopts = ["-rdynamic"],
+  deps = [
+    ":fnref",
+    "//best/test",
+  ],
+)
+
+cc_library(
   name = "tap",
   hdrs = ["tap.h"],
   deps = [

--- a/best/func/fnref.h
+++ b/best/func/fnref.h
@@ -1,0 +1,86 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_FUNC_FNREF_H_
+#define BEST_FUNC_FNREF_H_
+
+#include "best/func/internal/fnref.h"
+#include "best/meta/internal/abominable.h"
+#include "best/meta/taxonomy.h"
+
+//! Dynamic function references.
+//!
+//! A `best::fnref` is a type-erased function owned by a caller. It is similar
+//! to a `std::function`, but never allocates on the heap. It is useful for
+//! passing arbitrary callables into non-templates.
+
+namespace best {
+/// `best::fnref<R(...) const>`
+///
+/// A function reference. This type is a function pointer with associated data
+/// captured by reference. You can construct a `best::fnref` from a lambda or
+/// a function pointer, or another `best::fnref`, or any other callable.
+///
+/// The type of `Signature` must be some function type, such as `int()` or
+/// `void(int, int) const`. The `const` will indicate whether this function
+/// reference can be constructed from const references or not (in other words,
+/// whether or not this is a "mutable" function reference).
+///
+/// `best::fnref` is a somewhat dangerous type to return or place into a
+/// container. It's not forbidden, but it's something to do carefully.
+template <typename Signature>
+class fnref final : best::abominable_internal::tame<Signature>::template apply<
+                        fnref_internal::impl> {
+ private:
+  using impl_t = best::abominable_internal::tame<Signature>::template apply<
+      fnref_internal::impl>;
+
+ public:
+  /// # `fnref::output`
+  ///
+  /// The output of this function.
+  using output = impl_t::output;
+
+  /// # `fnref::is_const`
+  ///
+  /// Whether or not this is a "const" function reference.
+  static constexpr bool is_const = best::is_const_func<Signature>;
+  static_assert(!best::is_ref_func<Signature>,
+                "cannot use ref-qualified function types with best::fnref");
+
+  /// # `fnref::fnref()`
+  ///
+  /// Constructs a new fnref. It may be constructed from a closure, a function
+  /// pointer, or `nullptr`.
+  using impl_t::impl_t;
+
+  /// # `fnref()`
+  ///
+  /// Calls the function.
+  using impl_t::operator();
+
+  /// # `fnref::operator==`
+  ///
+  /// `fnref`s may be compared to `nullptr` (and no other pointer).
+  using impl_t::operator==;
+  using impl_t::operator bool;
+};
+}  // namespace best
+
+#endif  // BEST_FUNC_FNREF_H_

--- a/best/func/internal/fnref.h
+++ b/best/func/internal/fnref.h
@@ -1,0 +1,92 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_FUNC_INTERNAL_FNREF_H_
+#define BEST_FUNC_INTERNAL_FNREF_H_
+
+#include <cstddef>
+
+#include "best/func/call.h"
+#include "best/meta/taxonomy.h"
+
+namespace best::fnref_internal {
+template <typename Func, typename R, typename... Args>
+class impl {
+ public:
+  using output = R;
+
+  constexpr impl() = delete;
+
+  constexpr impl(std::nullptr_t) : ptr_(nullptr), fnptr_(nullptr) {}
+  constexpr impl(R (*fn)(Args...)) : ptr_(nullptr), fnptr_(fn) {}
+
+  constexpr impl(const auto& fn)
+    requires best::callable<decltype(fn), R(Args...)>
+      : ptr_(best::addr(fn)),
+        lambda_(+[](const void* captures, Args... args) -> R {
+          if constexpr (best::is_void<R>) {
+            best::call(
+                *reinterpret_cast<const best::unref<decltype(fn)>*>(captures),
+                BEST_FWD(args)...);
+          } else {
+            return best::call(
+                *reinterpret_cast<const best::unref<decltype(fn)>*>(captures),
+                BEST_FWD(args)...);
+          }
+        }) {}
+
+  constexpr impl(best::callable<R(Args...)> auto&& fn)
+    requires best::callable<decltype(fn), R(Args...)> &&
+                 (!best::is_const_func<Func>)
+      : ptr_(best::addr(fn)),
+        lambda_(+[](const void* captures, Args... args) -> R {
+          if constexpr (best::is_void<R>) {
+            best::call(*reinterpret_cast<best::unref<decltype(fn)>*>(
+                           const_cast<void*>(captures)),
+                       BEST_FWD(args)...);
+          } else {
+            return best::call(*reinterpret_cast<best::unref<decltype(fn)>*>(
+                                  const_cast<void*>(captures)),
+                              BEST_FWD(args)...);
+          }
+        }) {}
+
+  constexpr R operator()(Args... args) const {
+    if (ptr_) {
+      return lambda_(ptr_, BEST_FWD(args)...);
+    } else {
+      return fnptr_(BEST_FWD(args)...);
+    }
+  }
+
+  constexpr bool operator==(std::nullptr_t) const {
+    return ptr_ == nullptr && fnptr_ == nullptr;
+  }
+  constexpr explicit operator bool() const { return *this != nullptr; }
+
+ private:
+  const void* ptr_;
+  union {
+    R (*lambda_)(const void*, Args...);
+    R (*fnptr_)(Args...);
+  };
+};
+}  // namespace best::fnref_internal
+
+#endif  // BEST_FUNC_INTERNAL_FNREF_H_

--- a/best/log/BUILD
+++ b/best/log/BUILD
@@ -7,6 +7,7 @@ cc_library(
     "//best/base:port",
     "//best/base:fwd",
     "//best/meta:taxonomy",
+    "//best/func:fnref",
   ],
 )
 
@@ -18,4 +19,12 @@ cc_test(
     ":location",
     "//best/test",
   ]
+)
+
+cc_library(
+  name = "wtf",
+  hdrs = ["wtf.h"],
+  deps = [
+    "//best/text:format",
+  ],
 )

--- a/best/log/wtf.h
+++ b/best/log/wtf.h
@@ -1,0 +1,54 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_LOG_WTF_H_
+#define BEST_LOG_WTF_H_
+
+#include "best/text/format.h"
+#include "best/text/strbuf.h"
+
+//! Crashing and assertions.
+//!
+//! This header provides high-level functions for ending the current process
+//! with a formatted message.
+
+namespace best {
+/// # `best::wtf()`
+///
+/// Quickly exits the program due to an unexpected, unrecoverable condition. It
+/// prints a message using `best::format()` before exiting.
+///
+/// NOTE: This function is not currently async-signal-safe, because it
+/// allocates. This limitation will eventually be lifted.
+template <best::formattable... Args>
+[[noreturn]] void wtf(best::format_template<Args...> templ = "",
+                      const Args&... args) {
+  best::strbuf message = best::format(templ, args...);
+  auto write = [&](char* scratch, size_t scratch_len, auto write) {
+    if (message.is_empty()) {
+      message.push("explicit call to best::wtf()");
+    }
+    write(message.data(), message.size());
+  };
+
+  crash_internal::die(templ.where(), write);
+}
+}  // namespace best
+
+#endif  // BEST_LOG_WTF_H_

--- a/best/meta/internal/abominable.h
+++ b/best/meta/internal/abominable.h
@@ -31,16 +31,18 @@ struct tame {
   static constexpr bool c{}, v{}, l{}, r{};
 };
 
-#define BEST_TAME_(c_, v_, l_, r_, suffix_)           \
-  template <typename O, typename... I>                \
-  struct tame<O(I...) suffix_> {                      \
-    using type = O(I...);                             \
-    static constexpr bool c{c_}, v{v_}, l{l_}, r{r_}; \
-  };                                                  \
-  template <typename O, typename... I>                \
-  struct tame<O(I..., ...) suffix_> {                 \
-    using type = O(I..., ...);                        \
-    static constexpr bool c{c_}, v{v_}, l{l_}, r{r_}; \
+#define BEST_TAME_(c_, v_, l_, r_, suffix_)                              \
+  template <typename O, typename... I>                                   \
+  struct tame<O(I...) suffix_> {                                         \
+    using type = O(I...);                                                \
+    static constexpr bool c{c_}, v{v_}, l{l_}, r{r_};                    \
+    template <template <typename, typename, typename...> typename Trait> \
+    using apply = Trait<O(I...) suffix_, O, I...>;                       \
+  };                                                                     \
+  template <typename O, typename... I>                                   \
+  struct tame<O(I..., ...) suffix_> {                                    \
+    using type = O(I..., ...);                                           \
+    static constexpr bool c{c_}, v{v_}, l{l_}, r{r_};                    \
   }
 
 BEST_TAME_(0, 0, 0, 0, );

--- a/best/meta/taxonomy.h
+++ b/best/meta/taxonomy.h
@@ -117,6 +117,30 @@ concept is_tame_func = is_func<T> && requires { (T*){}; };
 template <typename T>
 concept is_abominable = is_func<T> && !requires { (T*){}; };
 
+/// # `best::is_const_func`
+///
+/// Whether this is a `const`-qualified abominable function.
+template <typename T>
+concept is_const_func = abominable_internal::tame<T>::c;
+
+/// # `best::is_lref_func`
+///
+/// Whether this is a `&`-qualified abominable function.
+template <typename T>
+concept is_lref_func = abominable_internal::tame<T>::l;
+
+/// # `best::is_rref_func`
+///
+/// Whether this is a `&&`-qualified abominable function.
+template <typename T>
+concept is_rref_func = abominable_internal::tame<T>::r;
+
+/// # `best::is_ref_func`
+///
+/// Whether this is a `&`- or `&&-qualified abominable function.
+template <typename T>
+concept is_ref_func = is_lref_func<T> || is_rref_func<T>;
+
 /// # `best::tame<T>`
 ///
 /// If `T` is an abominable function, returns its "tame" counterpart. Otherwise,

--- a/best/text/ascii.h
+++ b/best/text/ascii.h
@@ -52,7 +52,7 @@ struct ascii final {
     auto next = output->take_first(1).ok_or(encoding_error::OutOfBounds);
     BEST_GUARD(next);
 
-    (*next)[0] = rune;
+    (*next.ok())[0] = rune;
     return best::ok();
   }
 
@@ -61,7 +61,7 @@ struct ascii final {
     auto next = input->take_first(1).ok_or(encoding_error::OutOfBounds);
     BEST_GUARD(next);
 
-    return rune::from_int((*next)[0])
+    return rune::from_int((*next.ok())[0])
         .filter(&rune::is_ascii)
         .ok_or(encoding_error::Invalid);
   }
@@ -71,7 +71,7 @@ struct ascii final {
     auto next = input->take_last(1).ok_or(encoding_error::OutOfBounds);
     BEST_GUARD(next);
 
-    return rune::from_int((*next)[0])
+    return rune::from_int((*next.ok())[0])
         .filter(&rune::is_ascii)
         .ok_or(encoding_error::Invalid);
   }
@@ -101,7 +101,7 @@ struct latin1 final {
     auto next = output->take_first(1).ok_or(encoding_error::OutOfBounds);
     BEST_GUARD(next);
 
-    (*next)[0] = rune;
+    (*next.ok())[0] = rune;
     return best::ok();
   }
 
@@ -110,7 +110,7 @@ struct latin1 final {
     auto next = input->take_first(1).ok_or(encoding_error::OutOfBounds);
     BEST_GUARD(next);
 
-    return rune::from_int((*next)[0]).ok_or(encoding_error::Invalid);
+    return rune::from_int((*next.ok())[0]).ok_or(encoding_error::Invalid);
   }
 
   static constexpr best::result<rune, encoding_error> undecode(
@@ -118,7 +118,7 @@ struct latin1 final {
     auto next = input->take_last(1).ok_or(encoding_error::OutOfBounds);
     BEST_GUARD(next);
 
-    return rune::from_int((*next)[0]).ok_or(encoding_error::Invalid);
+    return rune::from_int((*next.ok())[0]).ok_or(encoding_error::Invalid);
   }
 
   constexpr bool operator==(const latin1&) const = default;

--- a/best/text/utf32.h
+++ b/best/text/utf32.h
@@ -61,7 +61,7 @@ struct utf32 final {
     auto next = output->take_first(1).ok_or(encoding_error::OutOfBounds);
     BEST_GUARD(next);
 
-    (*next)[0] = rune;
+    (*next.ok())[0] = rune;
     return best::ok();
   }
 
@@ -71,7 +71,7 @@ struct utf32 final {
     auto next = input->take_first(1).ok_or(encoding_error::OutOfBounds);
     BEST_GUARD(next);
 
-    return rune::from_int((*next)[0]).ok_or(encoding_error::Invalid);
+    return rune::from_int((*next.ok())[0]).ok_or(encoding_error::Invalid);
   }
 
   template <int = 0>
@@ -80,7 +80,7 @@ struct utf32 final {
     auto next = input->take_last(1).ok_or(encoding_error::OutOfBounds);
     BEST_GUARD(next);
 
-    return rune::from_int((*next)[0]).ok_or(encoding_error::Invalid);
+    return rune::from_int((*next.ok())[0]).ok_or(encoding_error::Invalid);
   }
 
   constexpr bool operator==(const utf32&) const = default;


### PR DESCRIPTION
`best::fnref` is an implementation of `absl::FunctionRef`, and `best::wtf()` is the "nice" entry-point for hard-crashing. I am uncertain on the name `best::wtf()`, I may potentially switch to `best::panic()` or `best::omg()`.

Also includes taxonomy traits for abominable function qualifiers, which `best::fnref` uses. 