### PR TITLE
Improve reflection tagging

### DIFF
--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -106,7 +106,7 @@ struct empty;
 class type_names;
 
 // best/meta/reflect.h
-template <typename>
+template <typename, typename>
 class mirror;
 template <auto&>
 class reflected_field;

--- a/best/meta/internal/reflect.h
+++ b/best/meta/internal/reflect.h
@@ -376,8 +376,8 @@ class tdesc final {
 
 struct reify {
   template <typename T>
-  static constexpr mirror<best::seal<tdesc<T, row<>, row<>>>,
-                          best::seal<best::row<>>>
+  static constexpr mirror<best::abridge<tdesc<T, row<>, row<>>>,
+                          best::abridge<best::row<>>>
       empty{{{}, {}, {}}, {}};
 
   template <typename T>

--- a/best/meta/internal/reflect.h
+++ b/best/meta/internal/reflect.h
@@ -36,6 +36,8 @@ namespace best::reflect_internal {
 using ::best::names_internal::eyepatch;
 using ::best::names_internal::materialize;
 
+struct tag {};
+
 // BestRowKeys for fdesc/vdesc.
 template <auto>
 struct fkey {};
@@ -353,9 +355,14 @@ class tdesc final {
   Tags tags_;
 };
 
-template <typename T, typename mirror = best::mirror<T>>
-  requires requires { BestReflect(mirror::BEST_MIRROR_FTADLE_, (T*){}); }
-inline constexpr auto desc = BestReflect(mirror::BEST_MIRROR_FTADLE_, (T*){});
+template <typename mirror>
+inline constexpr mirror make_mirror = mirror::BEST_MIRROR_EMPTY_();
+
+template <typename T,
+          typename mirror = best::mirror<best::seal<tdesc<T, row<>, row<>>>>>
+  requires requires { BestReflect(make_mirror<mirror>, (T*){}); }
+inline constexpr auto desc =
+    BestReflect(make_mirror<mirror>, (T*){}).BEST_MIRROR_UNWRAP_(tag{});
 };  // namespace best::reflect_internal
 
 #undef BEST_DESCRIPTOR_FRIENDS_

--- a/best/meta/internal/traits.h
+++ b/best/meta/internal/traits.h
@@ -39,6 +39,20 @@ struct select<false, A, B> {
 
 template <typename T>
 concept nonvoid = !std::is_void_v<T>;
+
+struct wax {};
+template <typename T, auto sealed = [](wax) { return T{}; }>
+  requires requires {
+    sealed(wax{});
+    +sealed;  // Ensure that the user isn't passing a generic lambda.
+  }
+inline constexpr auto seal = sealed;
+template <typename S>
+  requires requires(S sealed) {
+    sealed(wax{});
+    +sealed;  // Ensure that the user isn't passing a generic lambda.
+  }
+using unseal = decltype(S{}(wax{}));
 }  // namespace best::traits_internal
 
 #endif  // BEST_META_INTERNAL_TRAITS_H_

--- a/best/meta/reflect.h
+++ b/best/meta/reflect.h
@@ -89,8 +89,8 @@ constexpr auto fields(best::is_reflected_struct auto&& value) {
 template <typename Info_, typename With_>
 class mirror final {
  private:
-  using info_t = best::unseal<Info_>;
-  using with_t = best::unseal<With_>;
+  using info_t = best::unabridge<Info_>;
+  using with_t = best::unabridge<With_>;
 
  public:
   /// # `mirror::reflected`
@@ -155,7 +155,7 @@ class mirror final {
   with_t with_;
 };
 template <typename... Ts>
-mirror(Ts...) -> mirror<best::seal<Ts>...>;
+mirror(Ts...) -> mirror<best::abridge<Ts>...>;
 
 /// # `best::reflected_field`
 ///

--- a/best/meta/reflect.h
+++ b/best/meta/reflect.h
@@ -22,9 +22,9 @@
 
 #include "best/container/row.h"
 #include "best/container/span_sort.h"
-#include "best/func/tap.h"
 #include "best/meta/internal/reflect.h"
 #include "best/meta/taxonomy.h"
+#include "best/meta/traits.h"
 #include "best/text/str.h"
 
 //! Struct and enum reflection.
@@ -35,11 +35,8 @@
 //!
 //! ```
 //! friend constexpr auto BestReflect(auto& mirror, MyStruct*) {
-//!   return mirror.reflect(
-//!     "MyStruct",
-//!     mirror.field("foo", &MyStruct::foo),
-//!     mirror.field("bar", &MyStruct::bar),
-//!   );
+//!   return mirror.infer()
+//!     .with(best::vals<&MyStruct::some_field>, tags...);
 //! }
 //! ```
 
@@ -89,13 +86,16 @@ constexpr auto fields(best::is_reflected_struct auto&& value) {
 /// these reflections is an implementation detail, since they have complex type
 /// parameters. The mirror provides a friendlier API for manipulating these
 /// reflections.
-template <typename T>
+template <typename Impl_>
 class mirror final {
+ private:
+  using info_t = best::unseal<Impl_>;
+
  public:
-  /// # `mirror::empty()`
+  /// # `mirror::reflected`
   ///
-  /// Returns an empty reflection for `T`, with no fields attached.
-  constexpr auto empty() const;
+  /// The type this mirror reflects.
+  using reflected = info_t::type;
 
   /// # `mirror::infer()`
   ///
@@ -105,32 +105,25 @@ class mirror final {
   /// When `T` is an enum, it is possible to explicitly specify the range of
   /// values to consider for finding enum values.
   constexpr auto infer() const
-    requires best::is_struct<T> &&
-             ((reflect_internal::total_fields<T> <= BEST_REFLECT_MAX_FIELDS_));
+    requires best::is_struct<reflected> &&
+             ((reflect_internal::total_fields<reflected> <=
+               BEST_REFLECT_MAX_FIELDS_));
 
   template <best::bounds range = best::bounds{.end = 64}>
   constexpr auto infer() const
-    requires best::is_enum<T> && (range.try_compute_count({}).has_value());
+    requires best::is_enum<reflected> &&
+             (range.try_compute_count({}).has_value());
 
-  /// # `mirror.field()`
+  /// # `mirror.with()`
   ///
-  /// Reflects that `T` has the given data member.
-  ///
-  /// This returns a tap that can be applied to a reflection returned by
-  /// e.g. `infer()`. This is primarily intended for adding tags to the field.
+  /// Reflects that `T` has the given member. This can method
+  /// may be called multiple times, and can be used to add tags to a member.
   template <best::is_member_ptr auto mp>
-  constexpr auto field(best::vlist<mp>, auto... tags) const
-    requires best::is_struct<T>;
-
-  /// # `mirror.value()`
-  ///
-  /// Reflects that `T` has the given enum value.
-  ///
-  /// This returns a tap that can be applied to a reflection returned by
-  /// e.g. `infer()`. This is primarily intended for adding tags to the value.
+  constexpr auto with(best::vlist<mp>, auto... tags) const
+    requires best::is_struct<reflected>;
   template <best::is_enum auto e>
-  constexpr auto value(best::vlist<e>, auto... tags) const
-    requires best::is_enum<T>;
+  constexpr auto with(best::vlist<e>, auto... tags) const
+    requires best::is_enum<reflected>;
 
   /// # `mirror.hide()`
   ///
@@ -138,21 +131,34 @@ class mirror final {
   /// reflection.
   template <best::is_member_ptr auto mp>
   constexpr auto hide(best::vlist<mp>) const
-    requires best::is_struct<T>;
-
+    requires best::is_struct<reflected>;
   template <best::is_enum auto e>
   constexpr auto hide(best::vlist<e>) const
-    requires best::is_enum<T>;
+    requires best::is_enum<reflected>;
 
   mirror(const mirror&) = delete;
   mirror& operator=(const mirror&) = delete;
 
  private:
-  constexpr mirror() = default;
+  template <typename>
+  friend class mirror;
+
+  constexpr explicit mirror(best::reflect_internal::tag, info_t impl_)
+      : impl_(impl_) {}
+  info_t impl_;
 
  public:
-  static const mirror BEST_MIRROR_FTADLE_;
+  constexpr static auto BEST_MIRROR_EMPTY_() {
+    return mirror({}, {{}, {}, {}});
+  }
+
+  constexpr info_t BEST_MIRROR_UNWRAP_(best::reflect_internal::tag) const {
+    return impl_;
+  }
+#define BEST_MIRROR_UNWRAP_ _private
 };
+template <typename T>
+mirror(auto, T) -> mirror<best::seal<T>>;
 
 /// # `best::reflected_field`
 ///
@@ -369,11 +375,7 @@ class reflected_type final {
 \* ////////////////////////////////////////////////////////////////////////// */
 
 namespace best {
-template <typename T>
-inline constexpr mirror<T> mirror<T>::BEST_MIRROR_FTADLE_{};
-#define BEST_MIRROR_FTADLE_ _private
-
-// The default BEST_REFLECT impl.
+// The default BestReflect() impl.
 constexpr auto BestReflect(auto& mirror, auto*)
   requires requires { mirror.infer(); }
 {
@@ -381,64 +383,70 @@ constexpr auto BestReflect(auto& mirror, auto*)
 }
 
 template <typename T>
-template <best::is_member_ptr auto mp>
-constexpr auto mirror<T>::field(best::vlist<mp>, auto... tags) const
-  requires best::is_struct<T>
-{
-  return best::tap([=](reflect_internal::valid_reflection<T> auto&& refl) {
-    return refl.template add<mp>(tags...);
-  });
-}
-
-template <typename T>
-template <best::is_enum auto e>
-constexpr auto mirror<T>::value(best::vlist<e>, auto... tags) const
-  requires best::is_enum<T>
-{
-  return best::tap([=](reflect_internal::valid_reflection<T> auto&& refl) {
-    return refl.template add<e>(tags...);
-  });
-}
-
-template <typename T>
-template <best::is_member_ptr auto mp>
-constexpr auto mirror<T>::hide(best::vlist<mp>) const
-  requires best::is_struct<T>
-{
-  return best::tap([=](reflect_internal::valid_reflection<T> auto&& refl) {
-    return refl.template hide<mp>();
-  });
-}
-template <typename T>
-template <best::is_enum auto e>
-constexpr auto mirror<T>::hide(best::vlist<e>) const
-  requires best::is_enum<T>
-{
-  return best::tap([=](reflect_internal::valid_reflection<T> auto&& refl) {
-    return refl.template hide<e>();
-  });
-}
-
-template <typename T>
-constexpr auto mirror<T>::empty() const {
-  return reflect_internal::tdesc<T, best::row<>, best::row<>>{};
-}
-
-template <typename T>
 constexpr auto mirror<T>::infer() const
-  requires best::is_struct<T> &&
-           ((reflect_internal::total_fields<T> <= BEST_REFLECT_MAX_FIELDS_))
+  requires best::is_struct<reflected> &&
+           ((reflect_internal::total_fields<reflected> <=
+             BEST_REFLECT_MAX_FIELDS_))
 {
-  return reflect_internal::tdesc<T>::infer_struct();
+  return best::mirror{
+      reflect_internal::tag{},
+      reflect_internal::tdesc<reflected>::infer_struct(),
+  };
 }
 
 template <typename T>
 template <best::bounds range>
 constexpr auto best::mirror<T>::infer() const
-  requires best::is_enum<T> && (range.try_compute_count({}).has_value())
+  requires best::is_enum<reflected> && (range.try_compute_count({}).has_value())
 {
-  return reflect_internal::tdesc<T>::template infer_enum<
-      range.start, *range.try_compute_count({})>();
+  return best::mirror{
+      reflect_internal::tag{},
+      reflect_internal::tdesc<reflected>::template infer_enum<
+          range.start, *range.try_compute_count({})>(),
+  };
+}
+
+template <typename T>
+template <best::is_member_ptr auto mp>
+constexpr auto mirror<T>::with(best::vlist<mp>, auto... tags) const
+  requires best::is_struct<reflected>
+{
+  return best::mirror{
+      reflect_internal::tag{},
+      impl_.template add<mp>(tags...),
+  };
+}
+
+template <typename T>
+template <best::is_enum auto e>
+constexpr auto mirror<T>::with(best::vlist<e>, auto... tags) const
+  requires best::is_enum<reflected>
+{
+  return best::mirror{
+      reflect_internal::tag{},
+      impl_.template add<e>(tags...),
+  };
+}
+
+template <typename T>
+template <best::is_member_ptr auto mp>
+constexpr auto mirror<T>::hide(best::vlist<mp>) const
+  requires best::is_struct<reflected>
+{
+  return best::mirror{
+      reflect_internal::tag{},
+      impl_.template hide<mp>(),
+  };
+}
+template <typename T>
+template <best::is_enum auto e>
+constexpr auto mirror<T>::hide(best::vlist<e>) const
+  requires best::is_enum<reflected>
+{
+  return best::mirror{
+      reflect_internal::tag{},
+      impl_.template hide<e>(),
+  };
 }
 
 template <auto& desc_>

--- a/best/meta/reflect_test.cc
+++ b/best/meta/reflect_test.cc
@@ -45,8 +45,9 @@ struct MyType final {
 
   constexpr friend auto BestReflect(auto& m, MyType*) {
     return m.infer()
-        .with(best::vals<&MyType::y>, MyCallback([] { return 42; }))
-        .hide(best::vals<&MyType::transient>);
+        .with(best::str("foo"))
+        .with(&MyType::y, MyCallback([] { return 42; }))
+        .hide(&MyType::transient);
   }
 
   constexpr bool operator==(const MyType&) const = default;
@@ -55,7 +56,7 @@ static_assert(best::is_reflected_struct<MyType>);
 
 enum class MyEnum { A, B, C };
 constexpr auto BestReflect(auto& m, MyEnum*) {
-  return m.infer().with(best::vals<MyEnum::B>, MyCallback([] { return 57; }));
+  return m.infer().with(MyEnum::B, MyCallback([] { return 57; }));
 }
 
 static_assert(best::is_reflected_enum<MyEnum>);
@@ -74,6 +75,9 @@ best::test Fields = [](auto& t) {
 };
 
 best::test FindTag = [](auto& t) {
+  t.expect_eq(best::reflect<MyType>.tags(best::types<best::str>),
+              best::row("foo"));
+
   int found = -1;
   best::reflect<MyType>.each([&](auto field) {
     auto tags = field.tags(best::types<Tag>);

--- a/best/meta/reflect_test.cc
+++ b/best/meta/reflect_test.cc
@@ -45,8 +45,8 @@ struct MyType final {
 
   constexpr friend auto BestReflect(auto& m, MyType*) {
     return m.infer()
-               ->*m.field(best::vals<&MyType::y>, MyCallback([] { return 42; }))
-               ->*m.hide(best::vals<&MyType::transient>);
+        .with(best::vals<&MyType::y>, MyCallback([] { return 42; }))
+        .hide(best::vals<&MyType::transient>);
   }
 
   constexpr bool operator==(const MyType&) const = default;
@@ -55,8 +55,7 @@ static_assert(best::is_reflected_struct<MyType>);
 
 enum class MyEnum { A, B, C };
 constexpr auto BestReflect(auto& m, MyEnum*) {
-  return m.infer()->*m.value(best::vals<MyEnum::B>,
-                             MyCallback([] { return 57; }));
+  return m.infer().with(best::vals<MyEnum::B>, MyCallback([] { return 57; }));
 }
 
 static_assert(best::is_reflected_enum<MyEnum>);

--- a/best/meta/traits.h
+++ b/best/meta/traits.h
@@ -96,16 +96,16 @@ using select = traits_internal::select<cond, A, B>::type;
 template <bool cond, best::type_trait A, best::type_trait B>
 using select_trait = traits_internal::select<cond, A, B>::type::type;
 
-/// # `best::seal<T>`, `best::unseal<T>`
+/// # `best::abridge<T>`, `best::unabridge<T>`
 ///
-/// Seals a type.
+/// Abridges a type name.
 ///
 /// This produces a new type with a very small opaque name that can be
-/// `best::unseal`ed to produce the original type.
+/// `best::unabridge`ed to produce the original type.
 template <typename T>
-using seal = decltype(best::traits_internal::seal<best::id<T>>);
+using abridge = decltype(best::traits_internal::seal<best::id<T>>);
 template <typename Sealed>
-using unseal = best::traits_internal::unseal<Sealed>::type;
+using unabridge = best::traits_internal::unseal<Sealed>::type;
 }  // namespace best
 
 #endif  // BEST_META_TRAITS_H_

--- a/best/meta/traits.h
+++ b/best/meta/traits.h
@@ -95,6 +95,17 @@ using select = traits_internal::select<cond, A, B>::type;
 /// illegal construction if it would not be selected.
 template <bool cond, best::type_trait A, best::type_trait B>
 using select_trait = traits_internal::select<cond, A, B>::type::type;
+
+/// # `best::seal<T>`, `best::unseal<T>`
+///
+/// Seals a type.
+///
+/// This produces a new type with a very small opaque name that can be
+/// `best::unseal`ed to produce the original type.
+template <typename T>
+using seal = decltype(best::traits_internal::seal<best::id<T>>);
+template <typename Sealed>
+using unseal = best::traits_internal::unseal<Sealed>::type;
 }  // namespace best
 
 #endif  // BEST_META_TRAITS_H_


### PR DESCRIPTION
This change updates the `BestReflect()` tagging API to not require the tap operator (`->*`) or calls to `best::vals<>` to manually hoist arguments into the type system.

Instead, we observe that all of the requisite information for building a type descriptor with tags is already present at `constexpr` time, and therefore can all be hoisted into a `template <const auto&>`. If we add an extra reification step, we can record field keys (e.g. ptrs-to-member) as data members in the mirror object returned by `BestReflect()`, put the mirror object into a `constexpr` variable, then pass that to the function that constructs the complete type descriptor as a non-type template argument.

Additionally, this change adds:

- `best::abridge<T>`, a symbol abridgement helper.
- `best::mirror::with(tags)`, for adding tags directly to the reflected type, not one of its fields.