### PR TITLE
Speed up reflection and row operations

### DIFF
--- a/best/container/object.h
+++ b/best/container/object.h
@@ -496,6 +496,39 @@ class object final {
   constexpr cptr operator->() const { return as_ptr().operator->(); }
   constexpr ptr operator->() { return as_ptr().operator->(); }
 
+  /// # `object::or_empty()`
+  ///
+  /// Returns the result of `operator*`, or a `best::empty&` if `T` is of void
+  /// type.
+  constexpr decltype(auto) or_empty() const& {
+    if constexpr (best::is_void<T>) {
+      return BEST_OBJECT_VALUE_;
+    } else {
+      return **this;
+    }
+  }
+  constexpr decltype(auto) or_empty() & {
+    if constexpr (best::is_void<T>) {
+      return BEST_OBJECT_VALUE_;
+    } else {
+      return **this;
+    }
+  }
+  constexpr decltype(auto) or_empty() const&& {
+    if constexpr (best::is_void<T>) {
+      return BEST_MOVE(BEST_OBJECT_VALUE_);
+    } else {
+      return *BEST_MOVE(*this);
+    }
+  }
+  constexpr decltype(auto) or_empty() && {
+    if constexpr (best::is_void<T>) {
+      return BEST_MOVE(BEST_OBJECT_VALUE_);
+    } else {
+      return *BEST_MOVE(*this);
+    }
+  }
+
   // Comparisons are the obvious thing.
   constexpr bool operator==(const object& that) const
     requires best::equatable<T, T>

--- a/best/container/row.h
+++ b/best/container/row.h
@@ -1391,75 +1391,47 @@ constexpr auto row<A...>::scatter(best::tlist<Ts...> those_types,
 
 template <typename... A>
 constexpr decltype(auto) row<A...>::apply(auto&& f) const& {
-  return indices.apply([&](auto... i) -> decltype(auto) {
-    return best::call(BEST_FWD(f), get(i)...);
-  });
+  return this->apply_impl(
+      [&](auto&&... p) { return best::call(BEST_FWD(f), p.or_empty()...); });
 }
 template <typename... A>
 constexpr decltype(auto) row<A...>::apply(auto&& f) & {
-  return indices.apply([&](auto... i) -> decltype(auto) {
-    return best::call(BEST_FWD(f), get(i)...);
-  });
+  return this->apply_impl(
+      [&](auto&&... p) { return best::call(BEST_FWD(f), p.or_empty()...); });
 }
 template <typename... A>
 constexpr decltype(auto) row<A...>::apply(auto&& f) const&& {
-  return indices.apply([&](auto... i) -> decltype(auto) {
-    return best::call(BEST_FWD(f), BEST_MOVE(*this).get(i)...);
+  return this->apply_impl([&](auto&&... p) {
+    return best::call(BEST_FWD(f), BEST_MOVE(p).or_empty()...);
   });
 }
 template <typename... A>
 constexpr decltype(auto) row<A...>::apply(auto&& f) && {
-  return indices.apply([&](auto... i) -> decltype(auto) {
-    return best::call(BEST_FWD(f), BEST_MOVE(*this).get(i)...);
+  return this->apply_impl([&](auto&&... p) {
+    return best::call(BEST_FWD(f), BEST_MOVE(p).or_empty()...);
   });
 }
 
 template <typename... A>
 constexpr void row<A...>::each(auto&& f) const& {
-  indices.each([&]<size_t i> {
-    if constexpr (best::is_void<type<i>> &&
-                  best::callable<decltype(f), void()>) {
-      best::call(
-          static_cast<best::dependent<decltype(f), best::index_t<i>>&&>(f));
-    } else {
-      best::call(BEST_FWD(f), get(best::index<i>));
-    }
-  });
+  return this->apply_impl(
+      [&](auto&&... p) { (row_internal::object_call(BEST_FWD(f), p), ...); });
 }
 template <typename... A>
 constexpr void row<A...>::each(auto&& f) & {
-  indices.each([&]<size_t i> {
-    if constexpr (best::is_void<type<i>> &&
-                  best::callable<decltype(f), void()>) {
-      best::call(
-          static_cast<best::dependent<decltype(f), best::index_t<i>>&&>(f));
-    } else {
-      best::call(BEST_FWD(f), get(best::index<i>));
-    }
-  });
+  return this->apply_impl(
+      [&](auto&&... p) { (row_internal::object_call(BEST_FWD(f), p), ...); });
 }
 template <typename... A>
 constexpr void row<A...>::each(auto&& f) const&& {
-  indices.each([&]<size_t i> {
-    if constexpr (best::is_void<type<i>> &&
-                  best::callable<decltype(f), void()>) {
-      best::call(
-          static_cast<best::dependent<decltype(f), best::index_t<i>>&&>(f));
-    } else {
-      best::call(BEST_FWD(f), BEST_MOVE(*this).get(best::index<i>));
-    }
+  return this->apply_impl([&](auto&&... p) {
+    (row_internal::object_call(BEST_FWD(f), BEST_MOVE(p)), ...);
   });
 }
 template <typename... A>
 constexpr void row<A...>::each(auto&& f) && {
-  indices.each([&]<size_t i> {
-    if constexpr (best::is_void<type<i>> &&
-                  best::callable<decltype(f), void()>) {
-      best::call(
-          static_cast<best::dependent<decltype(f), best::index_t<i>>&&>(f));
-    } else {
-      best::call(BEST_FWD(f), BEST_MOVE(*this).get(best::index<i>));
-    }
+  return this->apply_impl([&](auto&&... p) {
+    (row_internal::object_call(BEST_FWD(f), BEST_MOVE(p)), ...);
   });
 }
 }  // namespace best

--- a/best/container/vec.h
+++ b/best/container/vec.h
@@ -122,7 +122,7 @@ class vec final {
   template <contiguous Range>
   vec(alloc alloc, Range&& range)
     requires best::constructible<T, best::data_type<Range>>
-  {
+      : vec(std::move(alloc)) {
     assign(range);
     // TODO: move optimization?
   }
@@ -138,7 +138,7 @@ class vec final {
   template <is_iter Iter>
   vec(alloc alloc, Iter&& iter)
     requires best::constructible<T, best::iter_type<Iter>>
-  {
+      : vec(std::move(alloc)) {
     reserve(iter.size_hint().lower);
     for (auto&& elem : iter) {
       push(BEST_FWD(elem));

--- a/best/func/call.h
+++ b/best/func/call.h
@@ -42,22 +42,7 @@ namespace best {
 ///
 /// Additionally, any type parameters passed to this function will be forwarded
 /// to `call`.
-template <typename... Ts>
-BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(auto &&...args)
-  requires requires {
-    call_internal::call(call_internal::tag<Ts...>{}, BEST_FWD(args)...);
-  }
-{
-  return call_internal::call(call_internal::tag<Ts...>{}, BEST_FWD(args)...);
-}
-template <auto... vs>
-BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(auto &&f, auto &&...args)
-  requires(sizeof...(vs) > 0) && requires {
-    BEST_FWD(f).template operator()<vs...>(BEST_FWD(args)...);
-  }
-{
-  return BEST_FWD(f).template operator()<vs...>(BEST_FWD(args)...);
-}
+using ::best::call_internal::call;
 
 /// # `best::call_devoid()`
 ///

--- a/best/func/internal/call.h
+++ b/best/func/internal/call.h
@@ -31,71 +31,95 @@ namespace best::call_internal {
 template <typename...>
 struct tag {};
 
-template <typename Class>
+template <typename... Ts, typename Class>
 BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(
-    tag<>, best::is_func auto Class::*member, auto&& self, auto&&... args)
-  requires requires { (self.*member)(BEST_FWD(args)...); }
+    best::is_func auto Class::*member, auto&& self, auto&&... args)
+  requires requires {
+    requires sizeof...(Ts) == 0;
+    (self.*member)(BEST_FWD(args)...);
+  }
 {
   return (BEST_FWD(self).*member)(BEST_FWD(args)...);
 }
-template <typename Class>
+template <typename... Ts, typename Class>
 BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(
-    tag<>, best::is_func auto Class::*member, auto* self, auto&&... args)
-  requires requires { (self->*member)(BEST_FWD(args)...); }
+    best::is_func auto Class::*member, auto* self, auto&&... args)
+  requires requires {
+    requires sizeof...(Ts) == 0;
+    (self->*member)(BEST_FWD(args)...);
+  }
 {
   return (self->*member)(BEST_FWD(args)...);
 }
 
-template <typename Class>
+template <typename... Ts, typename Class>
 BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(
-    tag<>, best::is_object auto Class::*member, auto&& self)
-  requires requires { self.*member; }
+    best::is_object auto Class::*member, auto&& self)
+  requires requires {
+    requires sizeof...(Ts) == 0;
+    self.*member;
+  }
 {
   return BEST_FWD(self).*member;
 }
-template <typename Class>
+template <typename... Ts, typename Class>
 BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(
-    tag<>, best::is_object auto Class::*member, auto* self)
-  requires requires { self->*member; }
+    best::is_object auto Class::*member, auto* self)
+  requires requires {
+    requires sizeof...(Ts) == 0;
+    self->*member;
+  }
 {
   return self->*member;
 }
 
-BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(tag<>, auto&& func,
-                                                    auto&&... args)
-  requires requires { func(BEST_FWD(args)...); }
+template <typename... Args>
+BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(auto&& func, auto&&... args)
+  requires requires {
+    requires sizeof...(Args) == 0;
+    func(BEST_FWD(args)...);
+  }
 {
   return BEST_FWD(func)(BEST_FWD(args)...);
 }
 template <typename... Args>
-BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(tag<Args...>, auto&& func,
-                                                    auto&&... args)
-  requires requires { func.template operator()<Args...>(BEST_FWD(args)...); } &&
-           (sizeof...(Args) > 0)
+BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(auto&& func, auto&&... args)
+  requires requires {
+    requires sizeof...(Args) > 0;
+    func.template operator()<Args...>(BEST_FWD(args)...);
+  }
 {
   return BEST_FWD(func).template operator()<Args...>(BEST_FWD(args)...);
 }
 
-BEST_INLINE_SYNTHETIC constexpr void call(tag<>) {}
+template <auto... targs>
+BEST_INLINE_SYNTHETIC constexpr decltype(auto) call(auto&& func, auto&&... args)
+  requires requires {
+    requires sizeof...(targs) > 0;
+    func.template operator()<targs...>(BEST_FWD(args)...);
+  }
+{
+  return BEST_FWD(func).template operator()<targs...>(BEST_FWD(args)...);
+}
+
+BEST_INLINE_SYNTHETIC constexpr void call() {}
 
 template <typename F, typename... TParams, typename R, typename... Args>
 constexpr bool can_call(tag<TParams...>, R (*)(Args...))
   requires requires(F f, Args... args) {
-    call_internal::call<TParams...>(tag<TParams...>{}, f, BEST_FWD(args)...);
+    call_internal::call<TParams...>(f, BEST_FWD(args)...);
   }
 {
   return best::is_void<R> ||
          best::convertible<R, decltype(call_internal::call<TParams...>(
-                                  tag<TParams...>{}, best::lie<F>,
-                                  best::lie<Args>...))>;
+                                  best::lie<F>, best::lie<Args>...))>;
 }
 
 template <typename F, typename... Args>
 auto call_result(tag<Args...>)
-    -> decltype(call_internal::call(tag<>{}, best::lie<F>, best::lie<Args>...));
+    -> decltype(call_internal::call(best::lie<F>, best::lie<Args>...));
 template <typename F, best::is_void V>
-auto call_result(tag<V>)
-    -> decltype(call_internal::call(tag<>{}, best::lie<F>));
+auto call_result(tag<V>) -> decltype(call_internal::call(best::lie<F>));
 }  // namespace best::call_internal
 
 #endif  // BEST_FUNC_INTERNAL_CALL_H_

--- a/best/iter/iter_test.cc
+++ b/best/iter/iter_test.cc
@@ -42,4 +42,18 @@ best::test Count = [](auto& t) {
               7);
   t.expect_eq(calls, 7);
 };
+
+best::test Enumerate = [](auto& t) {
+  best::vec pairs(best::bounds{.start = 5, .count = 7}.iter().enumerate());
+  t.expect_eq(pairs,
+              {{0, 5}, {1, 6}, {2, 7}, {3, 8}, {4, 9}, {5, 10}, {6, 11}});
+};
+
+best::test Take = [](auto& t) {
+  best::vec x0(best::bounds{.start = 5, .count = 7}.iter().take(3));
+  t.expect_eq(x0, {5, 6, 7});
+
+  best::vec x1(best::bounds{.start = 5, .count = 7}.iter().take(20));
+  t.expect_eq(x1, {5, 6, 7, 8, 9, 10, 11});
+};
 };  // namespace best::iter_test

--- a/best/math/bit_test.cc
+++ b/best/math/bit_test.cc
@@ -78,6 +78,8 @@ static_assert(best::next_pow2(3u) == 4);
 static_assert(best::next_pow2(4u) == 8);
 static_assert(best::wrapping_next_pow2(best::max_of<unsigned>) == 0);
 
+static_assert(best::next_pow2(size_t{4294967254}) == 4294967296);
+
 static_assert(best::bits_for(0u) == 0);
 static_assert(best::bits_for(1u) == 1);
 static_assert(best::bits_for(2u) == 2);

--- a/best/math/conv.h
+++ b/best/math/conv.h
@@ -78,10 +78,10 @@ constexpr best::result<Int, best::atoi_error> atoi(const string_type auto &str,
 
 #define BEST_ATOI_LOOP_(result_, op_)                             \
   do {                                                            \
-    result_ *= radix;                                             \
+    result_ *= Int(radix);                                        \
     auto digit = next->to_digit(radix).ok_or(best::atoi_error{}); \
     BEST_GUARD(digit);                                            \
-    result_ op_ *digit;                                           \
+    result_ op_ Int(*digit);                                      \
   } while ((next = runes.next()))
 
     if (cannot_overflow) {
@@ -97,10 +97,10 @@ constexpr best::result<Int, best::atoi_error> atoi(const string_type auto &str,
 #undef BEST_ATOI_LOOP_
 #define BEST_ATOI_LOOP_(result_, op_)                             \
   do {                                                            \
-    result_ *= radix;                                             \
+    result_ *= Int(radix);                                        \
     auto digit = next->to_digit(radix).ok_or(best::atoi_error{}); \
     BEST_GUARD(digit);                                            \
-    result_ op_ *digit;                                           \
+    result_ op_ Int(*digit);                                      \
     BEST_GUARD(result_.checked().ok_or(best::atoi_error{}));      \
   } while ((next = runes.next()))
 

--- a/best/math/int_test.cc
+++ b/best/math/int_test.cc
@@ -73,4 +73,6 @@ static_assert(best::checked_cast<unsigned>(-1).is_empty());
 static_assert(best::checked_cast<unsigned>(1) == 1);
 static_assert(best::checked_cast<int>(best::max_of<long>).is_empty());
 static_assert(best::checked_cast<int>(200ll) == 200);
+
+static_assert(best::same<best::common_int<int, size_t>, size_t>);
 }  // namespace best::int_test

--- a/best/math/overflow.h
+++ b/best/math/overflow.h
@@ -315,11 +315,11 @@ struct overflow {
 #define BEST_OF_BOILERPLATE_(op_, opeq_)                                  \
   BEST_INLINE_ALWAYS constexpr friend auto operator op_(overflow a,       \
                                                         integer auto b) { \
-    return a op_ overflow(b);                                             \
+    return a op_ best::overflow(b);                                       \
   }                                                                       \
   BEST_INLINE_ALWAYS constexpr friend auto operator op_(integer auto a,   \
                                                         overflow b) {     \
-    return overflow(a) op_ b;                                             \
+    return best::overflow(a) op_ b;                                       \
   }                                                                       \
                                                                           \
   template <integer J>                                                    \

--- a/best/math/overflow_test.cc
+++ b/best/math/overflow_test.cc
@@ -19,6 +19,8 @@
 
 #include "best/math/overflow.h"
 
+#include "best/math/int.h"
+
 namespace best::overflow_test {
 static_assert(overflow(max_of<int>) + 1 == overflow(min_of<int>, true));
 static_assert(overflow(min_of<int>) + 1 == overflow(min_of<int> + 1));
@@ -37,6 +39,9 @@ static_assert(overflow(min_of<int>) % -1 == overflow(min_of<int>, true));
 
 static_assert((overflow(42) << 33) == overflow(84, true));
 static_assert((overflow(42) >> 33) == overflow(21, true));
+
+static_assert((size_t(best::max_of<unsigned>) + overflow(1)).wrap() ==
+              4294967296);
 
 static_assert(best::saturating_add(max_of<int> - 5, 6) == best::max_of<int>);
 static_assert(best::saturating_add(min_of<int> + 5, -6) == best::min_of<int>);

--- a/best/memory/allocator.cc
+++ b/best/memory/allocator.cc
@@ -38,7 +38,9 @@ void* malloc::alloc(best::layout layout) {
   }
 
   if (best::unlikely(p == nullptr)) {
-    best::crash_internal::crash("malloc() returned a null pointer");
+    best::crash_internal::crash(
+        "malloc() returned a null pointer on layout %zu:%zu", layout.size(),
+        layout.align());
   }
   if (best::is_debug()) {
     std::memset(p, 0xcd, layout.size());
@@ -50,7 +52,9 @@ void* malloc::zalloc(best::layout layout) {
   if (layout.size() <= MaxAlign) {
     void* p = ::calloc(layout.size(), 1);
     if (best::unlikely(p == nullptr)) {
-      best::crash_internal::crash("calloc() returned a null pointer");
+      best::crash_internal::crash(
+          "calloc() returned a null pointer on layout %zu:%zu", layout.size(),
+          layout.align());
     }
     return p;
   }
@@ -64,7 +68,9 @@ void* malloc::realloc(void* ptr, best::layout old, best::layout layout) {
   if (layout.size() <= MaxAlign) {
     void* p = ::realloc(ptr, layout.size());
     if (best::unlikely(p == nullptr)) {
-      best::crash_internal::crash("realloc() returned a null pointer");
+      best::crash_internal::crash(
+          "realloc() returned a null pointer on layout %zu:%zu -> %zu:%zu",
+          old.size(), old.align(), layout.size(), layout.align());
     }
     return p;
   }

--- a/best/meta/internal/traits.h
+++ b/best/meta/internal/traits.h
@@ -41,17 +41,16 @@ template <typename T>
 concept nonvoid = !std::is_void_v<T>;
 
 struct wax {};
-template <typename T, auto sealed = [](wax) { return T{}; }>
-  requires requires {
-    sealed(wax{});
-    +sealed;  // Ensure that the user isn't passing a generic lambda.
-  }
+template <typename Sealed>
+concept sealed = requires(Sealed sealed) {
+  sealed(wax{});
+  +sealed;  // Ensure that the user isn't passing a generic lambda.
+};
+
+template <typename T, sealed auto sealed = [](wax) { return T{}; }>
 inline constexpr auto seal = sealed;
-template <typename S>
-  requires requires(S sealed) {
-    sealed(wax{});
-    +sealed;  // Ensure that the user isn't passing a generic lambda.
-  }
+
+template <sealed S>
 using unseal = decltype(S{}(wax{}));
 }  // namespace best::traits_internal
 

--- a/best/meta/reflect.h
+++ b/best/meta/reflect.h
@@ -86,11 +86,11 @@ constexpr auto fields(best::is_reflected_struct auto&& value) {
 /// these reflections is an implementation detail, since they have complex type
 /// parameters. The mirror provides a friendlier API for manipulating these
 /// reflections.
-template <typename Info_, typename With_>
+template <typename I, typename W>
 class mirror final {
  private:
-  using info_t = best::unabridge<Info_>;
-  using with_t = best::unabridge<With_>;
+  using info_t = best::unabridge<I>;
+  using with_t = best::unabridge<W>;
 
  public:
   /// # `mirror::reflected`

--- a/best/meta/traits.h
+++ b/best/meta/traits.h
@@ -104,8 +104,14 @@ using select_trait = traits_internal::select<cond, A, B>::type::type;
 /// `best::unabridge`ed to produce the original type.
 template <typename T>
 using abridge = decltype(best::traits_internal::seal<best::id<T>>);
-template <typename Sealed>
-using unabridge = best::traits_internal::unseal<Sealed>::type;
+template <typename T>
+using unabridge = best::traits_internal::unseal<T>::type;
+
+/// # `best::abridged<T>`
+///
+/// A type generated with `best::abridge<T>`.
+template <typename T>
+concept abridged = best::traits_internal::sealed<T>;
 }  // namespace best
 
 #endif  // BEST_META_TRAITS_H_


### PR DESCRIPTION
Building reflection for types that have a lot of field tags is currently pretty slow. After this patch it will still be slow, but a lot of unnecessary work has been removed. In particular, `best::row::apply` is now implemented directly as a primitive in `best::row_internal::impl`, which means each call does not slam `best::row::get` N times.

Profiling suggests a lot of time is wasted instantiating copies of `best::tlist`; that may be a worthwhile target for optimizing down the line (either by making instantiation cheaper or reducing the number of instantiations; it looks like it's currently linear-ish but there are almost certainly avoidable quadratic instantiations lurking).

Additionally, this change fixes bugs in `best::vec`, `best::overflow`, and `best::atoi` that this optimization refactor uncovered, and introduces `best::iter::take()`, which I needed for debugging one of the bugs. It also adds the `best::abridged` concept for detecting whether a type is a `best::abridged<T>`.