### PR TITLE
Make tests pass under `-c opt`

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -10,20 +10,34 @@ env:
 
 jobs:
   check_lints:
+    name: Check Lints
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Check format
-      run: ./format.sh
+      - name: Check Format
+        run: "./format.sh"
 
   build_and_test:
+    name: Build and Test (fastbuild)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Build everything
-      run: ./bazel build //...
+      - name: Build Everything
+        run: "./bazel build //... -c fastbuild"
 
-    - name: Run tests
-      run: ./bazel test //...
+      - name: Test Everything
+        run: "./bazel test //... -c fastbuild"
+
+  build_and_test_opt:
+    name: Build and Test (opt)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Everything
+        run: "./bazel build //... -c opt"
+
+      - name: Test Everything
+        run: "./bazel test //... -c opt"

--- a/best/func/fnref_test.cc
+++ b/best/func/fnref_test.cc
@@ -30,11 +30,17 @@ best::test FromFnptr = [](auto& t) {
 
   f = nullptr;
   t.expect_eq(f, nullptr);
+
+  f = [](int x) { return x - 42; };
+  t.expect_eq(f(8), -34);
 };
 
 best::test FromLambda = [](auto& t) {
   int total = 0;
-  best::fnref<int(int) const> f = [&](int x) { return total += x; };
+  auto f0 = [&](int x) { return total += x; };
+  best::fnref<int(int) const> f = f0;  // Need to hoist this, since fnref
+                                       // doesn't trigger RLE. Only causes a
+                                       // failure in opt mode.
 
   t.expect_eq(f(5), 5);
   t.expect_eq(total, 5);

--- a/best/meta/taxonomy.h
+++ b/best/meta/taxonomy.h
@@ -232,6 +232,13 @@ concept is_ptr = std::is_pointer_v<T>;
 template <typename T>
 concept is_member_ptr = std::is_member_pointer_v<T>;
 
+/// # `best::is_func_ptr`
+///
+/// Whether this is a function pointer type.
+template <typename T>
+concept is_func_ptr =
+    best::is_ptr<T> && best::is_func<std::remove_pointer_t<T>>;
+
 /// # `best::as_ptr<T>`
 ///
 /// If `T` is an object, void, or tame function type, returns a pointer to it.


### PR DESCRIPTION
Make everything pass with optimizations turned on. This revealed two UB bugs:

1.  `best::vec<T>` was manipulating `size_` directly, even when this would violate strict aliasing. This caused some tests to fail because loading `size_` would ignore stores made through `data()`, because `&size_` and `data()` cannot alias because they have different types. `size_` is now manipulated exclusively through `memcpy()`.

2. A UAF in `fnref_test.cc` (but not `best::fnref` itself).

Since I was already touching `best::fnref`, I added a small optimization when constructing a `best::fnref` from a no-capture lambda.