### PR TITLE
Move almost all view functions on `best::vec` and `best::strbuf` behind `operator->`

### DIFF
--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -72,6 +72,10 @@ class pun;
 // template <typename, best::option<size_t>>
 // class span;
 
+// best/func/arrow.h
+template <typename>
+class arrow;
+
 // best/func/fnref.h
 template <typename>
 class fnref;

--- a/best/cli/parser.cc
+++ b/best/cli/parser.cc
@@ -135,8 +135,8 @@ void normalize(best::strbuf& name, const auto& about) {
   }
 
   // TODO: also check the ends.
-  if (name.starts_with('-') || name.starts_with('_') ||
-      name.contains(&reserved_rune)) {
+  if (name->starts_with('-') || name->starts_with('_') ||
+      name->contains(&reserved_rune)) {
     best::wtf("field {}::{}'s name ({:?}) contains reserved runes",
               about.strukt->path(), about.field, name);
   }
@@ -342,8 +342,8 @@ void cli::init() {
   });
 
   // Now, sort the flags so we can bisect through them later.
-  impl_->sorted_flags.sort(&impl::entry::key);
-  impl_->sorted_subs.sort(&impl::entry::key);
+  impl_->sorted_flags->sort(&impl::entry::key);
+  impl_->sorted_subs->sort(&impl::entry::key);
 
   // Check for duplicates.
   best::option<best::str> prev;
@@ -647,7 +647,7 @@ best::strbuf cli::usage(best::pretext<wtf8> exe, bool hidden) const {
 
   best::format(out, "Usage: {}", exe);
   if (!parents.is_empty()) {
-    parents.reverse();
+    parents->reverse();
     for (auto sub : parents) {
       best::format(out, " {}", sub);
     }
@@ -809,7 +809,7 @@ best::strbuf cli::usage(best::pretext<wtf8> exe, bool hidden) const {
     }
 
     best::str prefix = e.key[{
-        .end = e.key.size() - e.key.split('.').last()->size(),
+        .end = e.key.size() - e.key->split('.').last()->size(),
     }];
     // Chop off everything past the last `.` to make the prefix.
 

--- a/best/container/BUILD
+++ b/best/container/BUILD
@@ -169,6 +169,7 @@ cc_library(
     ":object",
     ":option",
     ":span",
+    "//best/func:arrow",
     "//best/math:bit",
     "//best/math:overflow",
     "//best/memory:allocator",

--- a/best/container/span_test.cc
+++ b/best/container/span_test.cc
@@ -237,10 +237,10 @@ best::test FrontAndBack = [](auto& t) {
 
 best::test Swap = [](auto& t) {
   best::vec<int> ints = {1, 2, 3, 4, 5};
-  ints.as_span().swap(1, 2);
+  ints->swap(1, 2);
   t.expect_eq(ints, best::span{1, 3, 2, 4, 5});
 
-  ints.as_span().reverse();
+  ints->reverse();
   t.expect_eq(ints, best::span{5, 4, 2, 3, 1});
 };
 
@@ -332,13 +332,13 @@ best::test Sort = [](auto& t) {
   best::mark_sort_header_used();
 
   best::vec<int> ints = {5, 4, 3, 2, 1};
-  ints.as_span().sort();
+  ints->sort();
   t.expect_eq(ints, best::span{1, 2, 3, 4, 5});
 
-  ints.as_span().stable_sort([](int x) { return best::count_ones(x); });
+  ints->stable_sort([](int x) { return best::count_ones(x); });
   t.expect_eq(ints, best::span{1, 2, 4, 3, 5});
 
-  ints.as_span().sort([](int x, int y) { return y <=> x; });
+  ints->sort([](int x, int y) { return y <=> x; });
   t.expect_eq(ints, best::span{5, 4, 3, 2, 1});
 };
 

--- a/best/func/BUILD
+++ b/best/func/BUILD
@@ -1,6 +1,14 @@
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
+  name = "arrow",
+  hdrs = ["arrow.h"],
+  deps = [
+    "//best/meta:taxonomy",
+  ]
+)
+
+cc_library(
   name = "call",
   hdrs = [
     "call.h",

--- a/best/func/arrow.h
+++ b/best/func/arrow.h
@@ -1,0 +1,86 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_FUNC_ARROW_H_
+#define BEST_FUNC_ARROW_H_
+
+#include "best/meta/taxonomy.h"
+
+//! Arrows, helpers for implementing exotic `operator->`s.
+//!
+//! When C++ sees `a->b`, and `a` is not a raw pointer, it replaces it with
+//! `a.operator->()->b`. It does so recursively until it obtains a raw pointer.
+//!
+//! Suppose we wanted to return some kind of non-pointer view from `operator->`;
+//! for example, we want to inject all of the functions of some type `T` into
+//! our type `U`, findable by `->`. But it doesn't contain a `T` that we can
+//! return a pointer to!
+//!
+//! An obviously incorrect implementation of `operator->` in this case would be
+//!
+//! ```
+//! T* operator->() {
+//!   T view = ...;
+//!   return &view;
+//! }
+//! ```
+//!
+//! When the `operator->` returns, it returns a pointer to an object whose
+//! lifetime is over. Oops! However, we can instead return a `best::arrow`:
+//!
+//! ```
+//! best::arrow<T> operator->() {
+//!   return T{...};
+//! }
+//! ```
+//!
+//! Then, when C++ goes to desugar `a->b`, it will expand to
+//! `a.operator->()->b`, calling `U`'s `operator->`; then it will expand again
+//! to `a.operator->().operator->()->b`, calling `best::arrow::operator->()`.
+//!
+//! Because we returned an actual `T`, it is not destroyed until the end of the
+//! full expression, so the pointer that the final `->b` offsets will be valid.
+
+namespace best {
+/// # `best::arrow<T>`
+///
+/// A wrapper over a `T` that implements a `operator->` that returns a pointer
+/// to that value.
+template <typename T>
+class arrow final {
+ public:
+  constexpr arrow(auto&& arg) : value_(BEST_FWD(arg)) {}
+  constexpr const T* operator->() const { return best::addr(value_); }
+  constexpr T* operator->() { return best::addr(value_); }
+
+  arrow() = delete;
+  constexpr arrow(const arrow&) = default;
+  constexpr arrow& operator=(const arrow&) = default;
+  constexpr arrow(arrow&&) = default;
+  constexpr arrow& operator=(arrow&&) = default;
+
+ private:
+  T value_;
+};
+
+template <typename T>
+arrow(T&&) -> arrow<best::as_auto<T>>;
+}  // namespace best
+
+#endif  // BEST_FUNC_ARROW_H_

--- a/best/test/test.cc
+++ b/best/test/test.cc
@@ -77,7 +77,7 @@ bool test::run_all(const flags& flags) {
       if (test->name().contains(skip)) goto skip;
     }
     if (!flags.filters.is_empty()) {
-      auto found = flags.filters.as_span().contains(
+      auto found = flags.filters->contains(
           [&](const auto& f) { return test->name().contains(f); });
 
       if (!found) goto skip;

--- a/best/text/strbuf_test.cc
+++ b/best/text/strbuf_test.cc
@@ -104,126 +104,126 @@ best::test PushLossy = [](auto& t) {
 best::test Affix = [](auto& t) {
   best::strbuf haystack = "a complicated string. see solomon: 🐈‍⬛";
 
-  t.expect(haystack.starts_with("a complicated string"));
-  t.expect(!haystack.starts_with("complicated string"));
-  t.expect(haystack.starts_with(u"a complicated string"));
-  t.expect(!haystack.starts_with(u"complicated string"));
-  t.expect(haystack.starts_with(str("a complicated string")));
-  t.expect(!haystack.starts_with(str("complicated string")));
-  t.expect(haystack.starts_with(str16(u"a complicated string")));
-  t.expect(!haystack.starts_with(str16(u"complicated string")));
+  t.expect(haystack->starts_with("a complicated string"));
+  t.expect(!haystack->starts_with("complicated string"));
+  t.expect(haystack->starts_with(u"a complicated string"));
+  t.expect(!haystack->starts_with(u"complicated string"));
+  t.expect(haystack->starts_with(str("a complicated string")));
+  t.expect(!haystack->starts_with(str("complicated string")));
+  t.expect(haystack->starts_with(str16(u"a complicated string")));
+  t.expect(!haystack->starts_with(str16(u"complicated string")));
 
-  t.expect(haystack.starts_with('a'));
-  t.expect(!haystack.starts_with('z'));
-  t.expect(!haystack.starts_with(U'🧶'));
+  t.expect(haystack->starts_with('a'));
+  t.expect(!haystack->starts_with('z'));
+  t.expect(!haystack->starts_with(U'🧶'));
 };
 
 best::test Contains = [](auto& t) {
   best::strbuf haystack = "a complicated string. see solomon: 🐈‍⬛";
 
-  t.expect(haystack.contains("solomon"));
-  t.expect(!haystack.contains("daisy"));
-  t.expect(haystack.contains(u"solomon"));
-  t.expect(!haystack.contains(u"daisy"));
+  t.expect(haystack->contains("solomon"));
+  t.expect(!haystack->contains("daisy"));
+  t.expect(haystack->contains(u"solomon"));
+  t.expect(!haystack->contains(u"daisy"));
 
-  t.expect(haystack.contains(U'🐈'));
-  t.expect(!haystack.contains('z'));
-  t.expect(!haystack.contains(U'🍣'));
-  t.expect(haystack.contains(U"🐈‍⬛"));
+  t.expect(haystack->contains(U'🐈'));
+  t.expect(!haystack->contains('z'));
+  t.expect(!haystack->contains(U'🍣'));
+  t.expect(haystack->contains(U"🐈‍⬛"));
 };
 
 best::test Find = [](auto& t) {
   best::strbuf haystack = "a complicated string. see solomon: 🐈‍⬛";
 
-  t.expect_eq(haystack.find("solomon"), 26);
-  t.expect_eq(haystack.find("daisy"), best::none);
-  t.expect_eq(haystack.find(u"solomon"), 26);
-  t.expect_eq(haystack.find(u"daisy"), best::none);
+  t.expect_eq(haystack->find("solomon"), 26);
+  t.expect_eq(haystack->find("daisy"), best::none);
+  t.expect_eq(haystack->find(u"solomon"), 26);
+  t.expect_eq(haystack->find(u"daisy"), best::none);
 
-  t.expect_eq(haystack.find(U'🐈'), 35);
-  t.expect_eq(haystack.find('z'), best::none);
-  t.expect_eq(haystack.find(U'🍣'), best::none);
-  t.expect_eq(haystack.find(U"🐈‍⬛"), 35);
+  t.expect_eq(haystack->find(U'🐈'), 35);
+  t.expect_eq(haystack->find('z'), best::none);
+  t.expect_eq(haystack->find(U'🍣'), best::none);
+  t.expect_eq(haystack->find(U"🐈‍⬛"), 35);
 
-  t.expect_eq(haystack.find(&rune::is_ascii_punct), 20);
+  t.expect_eq(haystack->find(&rune::is_ascii_punct), 20);
 };
 
 best::test Find16 = [](auto& t) {
   best::strbuf16 haystack = u"a complicated string. see solomon: 🐈‍⬛";
 
-  t.expect_eq(haystack.find("solomon"), 26);
-  t.expect_eq(haystack.find("daisy"), best::none);
-  t.expect_eq(haystack.find(u"solomon"), 26);
-  t.expect_eq(haystack.find(u"daisy"), best::none);
+  t.expect_eq(haystack->find("solomon"), 26);
+  t.expect_eq(haystack->find("daisy"), best::none);
+  t.expect_eq(haystack->find(u"solomon"), 26);
+  t.expect_eq(haystack->find(u"daisy"), best::none);
 
-  t.expect_eq(haystack.find(U'🐈'), 35);
-  t.expect_eq(haystack.find('z'), best::none);
-  t.expect_eq(haystack.find(U'🍣'), best::none);
-  t.expect_eq(haystack.find(U"🐈‍⬛"), 35);
+  t.expect_eq(haystack->find(U'🐈'), 35);
+  t.expect_eq(haystack->find('z'), best::none);
+  t.expect_eq(haystack->find(U'🍣'), best::none);
+  t.expect_eq(haystack->find(U"🐈‍⬛"), 35);
 
-  t.expect_eq(haystack.find(&rune::is_ascii_punct), 20);
+  t.expect_eq(haystack->find(&rune::is_ascii_punct), 20);
 };
 
 best::test SplitAt = [](auto& t) {
   best::strbuf test = "黒猫";
 
-  t.expect_eq(test.split_at(0), best::row{"", "黒猫"});
-  t.expect_eq(test.split_at(1), best::none);
-  t.expect_eq(test.split_at(2), best::none);
-  t.expect_eq(test.split_at(3), best::row{"黒", "猫"});
-  t.expect_eq(test.split_at(4), best::none);
-  t.expect_eq(test.split_at(5), best::none);
-  t.expect_eq(test.split_at(6), best::row{"黒猫", ""});
+  t.expect_eq(test->split_at(0), best::row{"", "黒猫"});
+  t.expect_eq(test->split_at(1), best::none);
+  t.expect_eq(test->split_at(2), best::none);
+  t.expect_eq(test->split_at(3), best::row{"黒", "猫"});
+  t.expect_eq(test->split_at(4), best::none);
+  t.expect_eq(test->split_at(5), best::none);
+  t.expect_eq(test->split_at(6), best::row{"黒猫", ""});
 
   test = "🐈‍⬛";
 
-  t.expect_eq(test.split_at(0), best::row{"", "🐈‍⬛"});
-  t.expect_eq(test.split_at(1), best::none);
-  t.expect_eq(test.split_at(2), best::none);
-  t.expect_eq(test.split_at(3), best::none);
-  t.expect_eq(test.split_at(4), best::row{"🐈", "\u200d⬛"});
-  t.expect_eq(test.split_at(5), best::none);
-  t.expect_eq(test.split_at(6), best::none);
-  t.expect_eq(test.split_at(7), best::row{"🐈\u200d", "⬛"});
-  t.expect_eq(test.split_at(8), best::none);
-  t.expect_eq(test.split_at(9), best::none);
-  t.expect_eq(test.split_at(10), best::row{"🐈‍⬛", ""});
+  t.expect_eq(test->split_at(0), best::row{"", "🐈‍⬛"});
+  t.expect_eq(test->split_at(1), best::none);
+  t.expect_eq(test->split_at(2), best::none);
+  t.expect_eq(test->split_at(3), best::none);
+  t.expect_eq(test->split_at(4), best::row{"🐈", "\u200d⬛"});
+  t.expect_eq(test->split_at(5), best::none);
+  t.expect_eq(test->split_at(6), best::none);
+  t.expect_eq(test->split_at(7), best::row{"🐈\u200d", "⬛"});
+  t.expect_eq(test->split_at(8), best::none);
+  t.expect_eq(test->split_at(9), best::none);
+  t.expect_eq(test->split_at(10), best::row{"🐈‍⬛", ""});
 };
 
 best::test SplitAt16 = [](auto& t) {
   best::strbuf16 test = u"黒猫";
 
-  t.expect_eq(test.split_at(0), best::row{u"", u"黒猫"});
-  t.expect_eq(test.split_at(1), best::row{u"黒", u"猫"});
-  t.expect_eq(test.split_at(2), best::row{u"黒猫", u""});
+  t.expect_eq(test->split_at(0), best::row{u"", u"黒猫"});
+  t.expect_eq(test->split_at(1), best::row{u"黒", u"猫"});
+  t.expect_eq(test->split_at(2), best::row{u"黒猫", u""});
 
   test = u"🐈‍⬛";
 
-  t.expect_eq(test.split_at(0), best::row{u"", u"🐈‍⬛"});
-  t.expect_eq(test.split_at(1), best::none);
-  t.expect_eq(test.split_at(2), best::row{u"🐈", u"\u200d⬛"});
-  t.expect_eq(test.split_at(3), best::row{u"🐈\u200d", u"⬛"});
-  t.expect_eq(test.split_at(4), best::row{u"🐈‍⬛", u""});
+  t.expect_eq(test->split_at(0), best::row{u"", u"🐈‍⬛"});
+  t.expect_eq(test->split_at(1), best::none);
+  t.expect_eq(test->split_at(2), best::row{u"🐈", u"\u200d⬛"});
+  t.expect_eq(test->split_at(3), best::row{u"🐈\u200d", u"⬛"});
+  t.expect_eq(test->split_at(4), best::row{u"🐈‍⬛", u""});
 };
 
 best::test SplitOn = [](auto& t) {
   best::strbuf haystack = "a complicated string. see solomon: 🐈‍⬛";
 
-  t.expect_eq(haystack.split_once("solomon"),
+  t.expect_eq(haystack->split_once("solomon"),
               best::row{"a complicated string. see ", ": 🐈‍⬛"});
-  t.expect_eq(haystack.split_once("daisy"), best::none);
-  t.expect_eq(haystack.split_once(u"solomon"),
+  t.expect_eq(haystack->split_once("daisy"), best::none);
+  t.expect_eq(haystack->split_once(u"solomon"),
               best::row{"a complicated string. see ", ": 🐈‍⬛"});
-  t.expect_eq(haystack.split_once(u"daisy"), best::none);
+  t.expect_eq(haystack->split_once(u"daisy"), best::none);
 
-  t.expect_eq(haystack.split_once(U'🐈'),
+  t.expect_eq(haystack->split_once(U'🐈'),
               best::row{"a complicated string. see solomon: ", "\u200d⬛"});
-  t.expect_eq(haystack.split_once('z'), best::none);
-  t.expect_eq(haystack.split_once(U'🍣'), best::none);
-  t.expect_eq(haystack.split_once(U"🐈‍⬛"),
+  t.expect_eq(haystack->split_once('z'), best::none);
+  t.expect_eq(haystack->split_once(U'🍣'), best::none);
+  t.expect_eq(haystack->split_once(U"🐈‍⬛"),
               best::row{"a complicated string. see solomon: ", ""});
 
-  t.expect_eq(haystack.split_once(&rune::is_ascii_punct),
+  t.expect_eq(haystack->split_once(&rune::is_ascii_punct),
               best::row{"a complicated string", " see solomon: 🐈‍⬛"});
 };
 }  // namespace best::strbuf_test


### PR DESCRIPTION
This patch introduces `best::arrow<T>`, a helper for returning anything out of an `operator->`. The doc comment on the type explains why it exists and what C++ semantics it abuses.

`best::vec` and `best::strbuf` now have `operator->`s that effectively return `best::span` and `best::str`, respectively. This allows the removal of a ton of duplicated functions, and means that the owned types can't "lag" behind the unowned types! This also means that e.g. `best::box<T[]>` does not need to duplicate all of the functions from `best::span`, like to `best::vec` used to.