### PR TITLE
Overhaul `best::ptr`

### DIFF
--- a/best/base/BUILD
+++ b/best/base/BUILD
@@ -10,6 +10,15 @@ cc_library(
 )
 
 cc_library(
+  name = "access",
+  hdrs = ["access.h"],
+  deps = [
+    ":fwd",
+    "//best/meta:taxonomy",
+  ],
+)
+
+cc_library(
   name = "port",
   hdrs = ["port.h"],
 )

--- a/best/base/access.h
+++ b/best/base/access.h
@@ -32,15 +32,16 @@ namespace best {
 /// # `best::access`
 ///
 /// Befriend this type to allow best easy access to key type members that you
-/// may not want to make public API, such as `BestVtable`, `BestRowKey`, and so
-/// on.
+/// may not want to make public API, such as `BestPtrMetadata`, `BestRowKey`,
+/// and so on.
 class access final {
  private:
   ~access() = delete;
 
   // Types and other members we want access to.
   template <typename T>
-  using BestVtable = T::BestVtable;
+  requires requires { typename T::BestPtrMetadata; }
+  using BestPtrMetadata = T::BestPtrMetadata;
 
   template <typename T>
   static constexpr T constructor(auto&&... args)
@@ -50,8 +51,8 @@ class access final {
   }
 
   // Best types that can access them.
-  friend ::best::interface_internal::access;
+  friend ::best::ptr_internal::access;
 };
 }  // namespace best
 
-#endif  // BEST_BASE_FWD_H_
+#endif  // BEST_BASE_ACCESS_H_

--- a/best/base/access.h
+++ b/best/base/access.h
@@ -1,0 +1,57 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_BASE_ACCESS_H_
+#define BEST_BASE_ACCESS_H_
+
+#include "best/base/fwd.h"
+#include "best/meta/taxonomy.h"
+
+//! The access helper.
+//!
+//! `best::access` is an auxiliary type for allowing types to keep members that
+//! implement non-FTADLE extension points private.
+
+namespace best {
+/// # `best::access`
+///
+/// Befriend this type to allow best easy access to key type members that you
+/// may not want to make public API, such as `BestVtable`, `BestRowKey`, and so
+/// on.
+class access final {
+ private:
+  ~access() = delete;
+
+  // Types and other members we want access to.
+  template <typename T>
+  using BestVtable = T::BestVtable;
+
+  template <typename T>
+  static constexpr T constructor(auto&&... args)
+    requires requires { T(BEST_FWD(args)...); }
+  {
+    return T(BEST_FWD(args)...);
+  }
+
+  // Best types that can access them.
+  friend ::best::interface_internal::access;
+};
+}  // namespace best
+
+#endif  // BEST_BASE_FWD_H_

--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -177,7 +177,7 @@ struct utf32;
 class test;
 
 // Some internal types that need forward decls.
-namespace interface_internal {
+namespace ptr_internal {
 struct access;
 }
 }  // namespace best

--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -35,6 +35,9 @@
 //! best. Users SHOULD NOT forward-declared best types.
 
 namespace best {
+// best/base/access.h
+class access;
+
 // best/cli/cli.h
 struct argv_query;
 class cli;
@@ -107,11 +110,12 @@ struct int_range;
 template <typename>
 class track_location;
 
-// best/memory.ptr.h
+// best/memory/ptr.h
 template <typename>
 class ptr;
-class vtable;
-template <typename>
+
+// best/memory/vptr.h
+template <typename...>
 class vptr;
 
 // best/memory/span.h
@@ -172,6 +176,10 @@ struct utf32;
 // best/test/test.h
 class test;
 
+// Some internal types that need forward decls.
+namespace interface_internal {
+struct access;
+}
 }  // namespace best
 
 #endif  // BEST_BASE_FWD_H_

--- a/best/container/box.h
+++ b/best/container/box.h
@@ -21,11 +21,12 @@
 #define BEST_CONTAINER_BOX_H_
 
 #include "best/base/hint.h"
+#include "best/base/ord.h"
 #include "best/base/tags.h"
+#include "best/container/object.h"
 #include "best/memory/allocator.h"
 #include "best/memory/layout.h"
 #include "best/memory/ptr.h"
-#include "best/memory/span.h"
 #include "best/meta/init.h"
 
 //! Value boxing.
@@ -33,103 +34,179 @@
 //! Boxes are pointers to heap-allocated objects, essentially fulfilling the
 //! purpose of `std::unique_ptr` but with semantics closer to Rust's `Box<T>`
 //! type. In particular, unlike `std::unique_ptr`, they are copyable.
-//!
-//! There are three flavors: `best::box<T>`, a single value; `best::box<T[]>`,
-//! a heap-allocated array; `best::vbox<T>`, an upcast value.
 
 namespace best {
+/// # `best::is_box`
+///
+/// Whether `T` is some `best::box<U>`.
+template <typename T>
+concept is_box = requires {
+  requires !std::is_class_v<typename best::as_auto<T>::type> ||
+             !std::is_abstract_v<typename best::as_auto<T>::type>;
+  requires best::same<best::as_auto<T>,
+                      best::box<typename best::as_auto<T>::type,
+                                typename best::as_auto<T>::alloc>>;
+};
+
 /// # `best::box<T>`
 ///
 /// A non-null pointer to a value on the heap.
 template <typename T, typename A = best::malloc>
 class BEST_RELOCATABLE box final {
  public:
-  /// # `box::type`.
+  /// # `box::type`
   ///
   /// The wrapped type; `box<T>` is nominally a `T*`.
   using type = T;
 
-  /// # `box::pointee`.
+  /// # `box::ptr`
   ///
-  /// The "true" pointee type. Internally, an `box` stores a `pointee*`.
-  using pointee = best::ptr<T>::pointee;
+  /// The pointer type for this box.
+  using ptr = best::ptr<T>;
 
-  using cref = best::as_ref<const T>;
-  using ref = best::as_ref<T>;
-  using crref = best::as_rref<const T>;
-  using rref = best::as_rref<T>;
-  using cptr = best::as_ptr<const type>;
-  using ptr = best::as_ptr<type>;
+  /// # `box::pointee`, `box::meta`
+  ///
+  /// The pointer component types for this box.
+  using pointee = ptr::pointee;
+  using metadata = ptr::metadata;
 
+  /// # `box::alloc`
+  ///
+  /// The allocator type for this box.
   using alloc = A;
 
-  box() = delete;
+ private:
+  // Helper for making requires clauses cleaner.
+  static constexpr bool thin = ptr::is_thin();
 
+ public:
   /// # `box::box(box)`
   ///
   /// Trivially relocatable. Copies perform memory allocations.
-  box(const box& that) requires best::copyable<T> && best::copyable<alloc>;
-  box& operator=(const box& that) requires best::copyable<T>;
-  box(box&& that) requires best::moveable<alloc>;
-  box& operator=(box&& that) requires best::moveable<alloc>;
-
-  /// # `box::box(value)`
-  ///
-  /// Wraps a value by copying/moving out from it.
-  explicit box(const T& from) : box(best::in_place, from) {}
-  explicit box(T&& from) : box(best::in_place, BEST_MOVE(from)) {}
-  explicit box(alloc alloc, const T& from)
-    : box(BEST_FWD(alloc), best::in_place, from) {}
-  explicit box(alloc alloc, T&& from)
-    : box(BEST_FWD(alloc), best::in_place, BEST_MOVE(from)) {}
+  constexpr box(const box& that) requires requires(ptr p) {
+    requires best::copyable<alloc>;
+    p.copy(p);
+  };
+  constexpr box& operator=(const box& that)
+    requires requires(ptr p) { p.copy_assign(p); };
+  constexpr box(box&& that) requires best::moveable<alloc>;
+  constexpr box& operator=(box&& that) requires best::moveable<alloc>;
 
   /// # `box::box(...)`
   ///
   /// Constructs a box by calling a constructor in-place.
-  explicit box(best::in_place_t, auto&&... args)
+  constexpr explicit box(auto&&... args)
+    requires best::constructible<alloc> &&
+             best::ptr_constructible<T, decltype(args)&&...> &&
+             (!best::is_box<decltype(args)> && ...)
     : box(alloc{}, best::in_place, BEST_FWD(args)...) {}
-  explicit box(alloc alloc, best::in_place_t, auto&&... args)
+  template <typename U>
+  constexpr explicit box(std::initializer_list<U> il, auto&&... args)
+    requires best::constructible<alloc> &&
+             best::ptr_constructible<T, std::initializer_list<U>,
+                                     decltype(args)&&...>
+    : box(alloc{}, best::in_place, il, BEST_FWD(args)...) {}
+  constexpr explicit box(best::in_place_t, auto&&... args)
+    requires best::constructible<alloc> &&
+             best::ptr_constructible<T, decltype(args)&&...>
+    : box(alloc{}, best::in_place, BEST_FWD(args)...) {}
+  constexpr explicit box(alloc alloc, best::in_place_t, auto&&... args)
+    requires best::ptr_constructible<T, decltype(args)&&...>
     : alloc_(best::in_place, BEST_FWD(alloc)) {
-    ptr_ =
-      best::ptr(allocator().alloc(best::layout::of<T>())).cast(best::types<T>);
+    ptr null{nullptr, ptr::meta_for(BEST_FWD(args)...)};
+
+    ptr_ = {
+      allocator().alloc(null.layout()).cast(best::types<pointee>),
+      null.meta(),
+    };
     ptr_.construct(BEST_FWD(args)...);
   }
+
+  template <best::ptr_losslessly_converts_to<T> U>
+  constexpr explicit box(box<U>&& that)
+    : box(unsafe("this is ok, because we only allow lossless conversions"),
+          BEST_MOVE(that.allocator()), BEST_MOVE(that).leak()) {}
 
   /// # `box::box(unsafe, ptr)`
   ///
   /// Wraps a pointer in a box. This pointer MUST have been allocated using
   /// the given allocated, with the layout of `T`.
-  explicit box(unsafe u, best::ptr<T> ptr) : box(u, alloc{}, ptr) {}
-  explicit box(unsafe u, alloc alloc, best::ptr<T> ptr)
+  constexpr explicit box(unsafe u, best::ptr<T> ptr) : box(u, alloc{}, ptr) {}
+  constexpr explicit box(unsafe u, alloc alloc, best::ptr<T> ptr)
     : ptr_(ptr), alloc_(best::in_place, BEST_FWD(alloc)) {}
 
   /// # `box::~box()`
   ///
   /// Boxes automatically destroy their contents.
-  ~box() {
-    if (ptr_ == best::ptr<T>::dangling()) { return; }
+  constexpr ~box() {
+    if (ptr_.raw() == best::ptr<T>::dangling().raw()) { return; }
 
     ptr_.destroy();
-    allocator().dealloc(ptr_.raw(), best::layout::of<T>());
+    allocator().dealloc(ptr_.raw(), ptr_.layout());
   }
 
   /// # `box::as_ptr()`
   ///
   /// Returns the underlying `best::ptr`.
-  best::ptr<T> as_ptr() const { return ptr_; }
+  constexpr best::ptr<T> as_ptr() const { return ptr_; }
 
   /// # `box::allocator()`
   ///
   /// Returns a reference to the box's allocator.
-  const alloc& allocator() const { return *alloc_; }
-  alloc& allocator() { return *alloc_; }
+  constexpr const alloc& allocator() const { return *alloc_; }
+  constexpr alloc& allocator() { return *alloc_; }
+
+  /// # `box::raw()`, `box::meta()`
+  ///
+  /// Returns the raw underlying pointer and its metadata.
+  constexpr pointee* raw() const { return as_ptr().raw(); }
+  constexpr metadata meta() const { return as_ptr().meta(); }
+
+  /// # `box::layout()`,
+  ///
+  /// Returns the layout of the pointed-to value.
+  constexpr best::layout layout() const { return as_ptr().layout(); }
+
+  /// # `box::operator*, box::operator->`
+  ///
+  /// Dereferences the box. Note that boxes cannot be null!
+  ///
+  /// Unlike `std::unique_ptr<T>`, dereferencing preserves the constness and
+  /// value category of the box.
+  constexpr decltype(auto) operator*() const& { return *ptr_.as_const(); }
+  constexpr decltype(auto) operator*() & { return *ptr_; }
+  constexpr decltype(auto) operator*() const&& {
+    return BEST_MOVE(*ptr_.as_const());
+  }
+  constexpr decltype(auto) operator*() && { return BEST_MOVE(*ptr_); }
+  constexpr auto operator->() const { return ptr_.as_const().operator->(); }
+  constexpr auto operator->() { return ptr_.operator->(); }
+
+  /// # `box[idx]`, `box(idx)`
+  ///
+  /// If the pointee of this `box` is indexable or callable, these functions
+  /// will forward to it.
+  // clang-format off
+  constexpr decltype(auto) operator[](size_t i) const requires requires { as_ptr()[i]; } { return as_ptr()[i]; }
+  constexpr decltype(auto) operator[](size_t i) requires requires { as_ptr()[i]; } { return as_ptr()[i]; }
+  constexpr decltype(auto) operator[](bounds i) const requires requires { as_ptr()[i]; } { return as_ptr()[i]; }
+  constexpr decltype(auto) operator[](bounds i) requires requires { as_ptr()[i]; } { return as_ptr()[i]; }
+  constexpr decltype(auto) operator[](auto&& i) const requires requires { as_ptr()[i]; } { return as_ptr()[i]; }
+  constexpr decltype(auto) operator[](auto&& i) requires requires { as_ptr()[i]; } { return as_ptr()[i]; }
+  constexpr decltype(auto) operator()(auto&&... args) const requires requires { as_ptr()(BEST_FWD(args)...); } {
+    return as_ptr()(BEST_FWD(args)...);
+  }
+  constexpr decltype(auto) operator()(auto&&... args) requires requires { as_ptr()(BEST_FWD(args)...); } {
+    return as_ptr()(BEST_FWD(args)...);
+  }
+  // clang-format on
 
   /// # `box::into_raw()`
   ///
   /// Explodes this box into its raw parts, and inhibits the destructor. The
   /// resulting pointer must be freed using the returned allocator at the end of
   /// the object's lifetime.
-  best::row<best::ptr<T>, alloc> into_raw() && {
+  constexpr best::row<best::ptr<T>, alloc> into_raw() && {
     auto ptr = std::exchange(ptr_, best::ptr<T>::dangling());
     return {ptr, *BEST_MOVE(alloc_)};
   }
@@ -138,50 +215,51 @@ class BEST_RELOCATABLE box final {
   ///
   /// Disables this `box`'s destructor and returns the pointer. This function
   /// explicitly leaks memory by withholding the call to `dealloc()`.
-  best::ptr<T> leak() && { return BEST_MOVE(*this).into_raw().first(); }
+  constexpr best::ptr<T> leak() && {
+    return BEST_MOVE(*this).into_raw().first();
+  }
 
-  /// # `box::operator*, box::operator->`
-  ///
-  /// Dereferences the box. Note that boxes cannot be null!
-  ///
-  /// Unlike `std::unique_ptr<T>`, dereferencing preserves the constness and
-  /// value category of the box.
-  cref operator*() const& { return *ptr_; }
-  ref operator*() & { return *ptr_; }
-  crref operator*() const&& { return BEST_MOVE(*ptr_); }
-  rref operator*() && { return BEST_MOVE(*ptr_); }
-  cptr operator->() const { return ptr_.operator->(); }
-  ptr operator->() { return ptr_.operator->(); }
-
-  friend void BestFmt(auto& fmt, const box& box)
-    requires requires { fmt.format(*box); }
-  {
-    fmt.format(*box);
+  friend void BestFmt(auto& fmt, const box& box) {
+    if constexpr (requires { fmt.format(*box); }) {
+      if (fmt.current_spec().method != 'p') { fmt.format(*box); }
+      return;
+    }
+    fmt.format(box.as_ptr());
   }
   constexpr friend void BestFmtQuery(auto& query, box*) {
     query = query.template of<T>;
+    query.uses_method = [](auto r) {
+      if (r == 'p') { return true; }
+      auto that = best::as_auto<decltype(query)>::template of<T>.uses_method;
+      return that && that(r);
+    };
   }
 
-  template <best::equatable<T> U>
-  bool operator==(const best::box<U>& that) const {
+  template <typename U>
+  constexpr bool operator==(const best::box<U>& that) const
+    requires best::equatable<best::view<T>, best::view<U>>
+  {
     return **this == *that;
   }
-  template <best::equatable<T> U>
-  bool operator==(const U& u) const {
+  template <best::equatable<best::view<T>> U>
+  constexpr bool operator==(const U& u) const {
     return **this == u;
   }
 
-  template <best::comparable<T> U>
-  best::order_type<T, U> operator<=>(const best::box<U>& that) const {
+  template <typename U>
+  constexpr best::order_type<best::view<T>, best::view<U>> operator<=>(
+    const best::box<U>& that) const
+    requires best::comparable<best::view<T>, best::view<U>>
+  {
     return **this <=> *that;
   }
-  template <best::comparable<T> U>
-  best::order_type<T, U> operator<=>(const U& u) const {
+  template <best::comparable<best::view<T>> U>
+  constexpr best::order_type<best::view<T>, U> operator<=>(const U& u) const {
     return **this <=> u;
   }
 
-  explicit box(niche) : ptr_(nullptr) {}
-  bool operator==(niche) const { return ptr_ == nullptr; }
+  constexpr explicit box(niche) : ptr_(nullptr) {}
+  constexpr bool operator==(niche) const { return ptr_ == nullptr; }
 
  private:
   template <typename, typename>
@@ -191,307 +269,11 @@ class BEST_RELOCATABLE box final {
   [[no_unique_address]] best::object<alloc> alloc_;
 };
 
-template <typename T>
+template <best::is_thin T>
 box(T&&) -> box<best::as_auto<T>>;
+template <best::is_object T>
+box(std::initializer_list<T>) -> box<T[]>;
 
-/// # `best::box<T[]>`
-///
-/// A non-null pointer to an array on the heap.
-template <typename T, typename A>
-class BEST_RELOCATABLE box<T[], A> final {
- public:
-  /// # `box::type`.
-  ///
-  /// The wrapped type; `ptr<T>` is nominally a `T*`.
-  using type = T;
-
-  /// # `box::pointee`.
-  ///
-  /// The "true" pointee type. Internally, an `box` stores a `pointee*`.
-  using pointee = best::ptr<T>::pointee;
-
-  using cref = best::as_ref<const T>;
-  using ref = best::as_ref<T>;
-  using crref = best::as_rref<const T>;
-  using rref = best::as_rref<T>;
-  using cptr = best::as_ptr<const type>;
-  using ptr = best::as_ptr<type>;
-
-  using alloc = A;
-
-  /// # `box::box()`
-  ///
-  /// Constructs an empty array box.
-  box() : box(best::span<T>{}) {}
-
-  /// # `box::box(box)`
-  ///
-  /// Trivially relocatable. Copies perform memory allocations.
-  box(const box& that) requires best::copyable<T> && best::copyable<alloc>;
-  box& operator=(const box& that) requires best::copyable<T>;
-  box(box&& that) requires best::moveable<alloc>;
-  box& operator=(box&& that) requires best::moveable<alloc>;
-
-  /// # `box::box(...)`
-  ///
-  /// Constructs a box by copying out of a span.
-  template <typename U = const T>
-  explicit box(best::span<U> args) : box(alloc{}, args) {}
-  template <typename U = const T>
-  explicit box(alloc alloc, best::span<U> args)
-    : size_(args.size()), alloc_(best::in_place, BEST_FWD(alloc)) {
-    if (size_ == 0) { return; }
-    ptr_ = best::ptr(allocator().alloc(best::layout::array<T>(args.size())))
-             .cast(best::types<T>);
-    as_span().emplace_from(args);
-  }
-
-  /// # `box::box(unsafe, ...)`
-  ///
-  /// Constructs a box by taking ownership of a span.
-  explicit box(unsafe, best::span<T> args) : box(alloc{}, args) {}
-  explicit box(unsafe, alloc alloc, best::span<T> args)
-    : ptr_(args.data()),
-      size_(args.size()),
-      alloc_(best::in_place, BEST_FWD(alloc)) {}
-
-  /// # `box::~box()`
-  ///
-  /// Boxes automatically destroy their contents.
-  ~box() {
-    if (data() == best::ptr<T>::dangling()) { return; }
-
-    as_span().destroy();
-    alloc_->dealloc(data(), best::layout::array<T>(size()));
-  }
-
-  /// # `box::as_ptr()`
-  ///
-  /// Returns the underlying `best::ptr`.
-  best::ptr<T> as_ptr() const { return ptr_; }
-
-  /// # `box::allocator()`
-  ///
-  /// Returns a reference to the box's allocator.
-  const alloc& allocator() const { return *alloc_; }
-  alloc& allocator() { return *alloc_; }
-
-  /// # `vec::data()`.
-  ///
-  /// Returns a pointer to the start of the array this box manages.
-  best::ptr<const T> data() const { return ptr_; }
-  best::ptr<T> data() { return ptr_; }
-
-  /// # `vec::size()`.
-  ///
-  /// Returns the number of elements in this vector.
-  size_t size() const { return size_; }
-
-  /// # `vec::is_empty()`.
-  ///
-  /// Returns whether this is an empty vector.
-  bool is_empty() const { return size() == 0; }
-
-  /// # `box::as_span()`, `box::operator->()`
-  ///
-  /// Returns a span over the array this box manages.
-  ///
-  /// All of the span methods, including those not explicitly delegated, are
-  /// accessible through `->`. For example, `my_box->sort()` works.
-  best::span<const T> as_span() const { return {ptr_, size_}; }
-  best::span<T> as_span() { return {ptr_, size_}; }
-  best::arrow<best::span<const T>> operator->() const { return as_span(); }
-  best::arrow<best::span<T>> operator->() { return as_span(); }
-
-  /// # `box::into_raw()`
-  ///
-  /// Explodes this box into its raw parts, and inhibits the destructor. The
-  /// resulting pointer must be freed using the returned allocator at the end of
-  /// the object's lifetime.
-  best::row<best::span<T>, alloc> into_raw() && {
-    auto ptr = std::exchange(ptr_, best::ptr<T>::dangling());
-    return {{ptr, size_}, *BEST_MOVE(alloc_)};
-  }
-
-  /// # `box::leak()`
-  ///
-  /// Disables this `box`'s destructor and returns the span. This function
-  /// explicitly leaks memory by withholding the call to `dealloc()`.
-  best::span<T> leak() && { return BEST_MOVE(*this).into_raw().first(); }
-
-  /// # `box[idx]`, `box[{.start = ...}]`
-  ///
-  /// Extracts a single element or a subspan. Crashes if the requested index is
-  /// out-of-bounds.
-  const T& operator[](best::track_location<size_t> idx) const {
-    return as_span()[idx];
-  }
-  T& operator[](best::track_location<size_t> idx) { return as_span()[idx]; }
-  best::span<const T> operator[](best::bounds::with_location range) const {
-    return as_span()[range];
-  }
-  best::span<T> operator[](best::bounds::with_location range) {
-    return as_span()[range];
-  }
-
-  /// # `box::at(idx)`, `box::at({.start = ...})`
-  ///
-  /// Extracts a single element or a subspan. If the requested index is
-  /// out-of-bounds, returns `best::none`.
-  best::option<const T&> at(size_t idx) const { return as_span().at(idx); }
-  best::option<T&> at(size_t idx) { return as_span().at(idx); }
-  best::option<const T&> at(best::bounds b) const { return as_span().at(b); }
-  best::option<T&> at(best::bounds b) { return as_span().at(b); }
-
-  /// # `box::citer`, `box::iter`, `box::begin()`, `box::end()`.
-  ///
-  /// Spans are iterable exactly how you'd expect.
-  using const_iterator = best::span<const T>::iterator;
-  using iterator = best::span<T>::iterator;
-  const_iterator iter() const { return as_span().iter(); }
-  iterator iter() { return as_span().iter(); }
-  auto begin() const { return as_span().begin(); }
-  auto end() const { return as_span().end(); }
-  auto begin() { return as_span().begin(); }
-  auto end() { return as_span().end(); }
-
-  explicit box(niche) : ptr_(nullptr) {}
-  bool operator==(niche) const { return ptr_ == nullptr; }
-
- private:
-  best::ptr<T> ptr_ = best::ptr<T>::dangling();
-  size_t size_;
-  [[no_unique_address]] best::object<alloc> alloc_;
-};
-
-/// # `best::vbox<T>`
-///
-/// A non-null pointer to a type-erased value on the heap.
-template <typename T, typename A = best::malloc>
-class BEST_RELOCATABLE vbox final {
- public:
-  /// # `vbox::type`.
-  ///
-  /// The wrapped type; `vbox<T>` is nominally a `T*`.
-  using type = T;
-
-  /// # `vbox::pointee`.
-  ///
-  /// The "true" pointee type. Internally, an `vbox` stores a `pointee*`.
-  using pointee = best::ptr<T>::pointee;
-
-  using cref = best::as_ref<const T>;
-  using ref = best::as_ref<T>;
-  using crref = best::as_rref<const T>;
-  using rref = best::as_rref<T>;
-  using cptr = best::as_ptr<const type>;
-  using ptr = best::as_ptr<type>;
-
-  using alloc = A;
-
-  vbox() = delete;
-
-  /// # `vbox::vbox(box)`
-  ///
-  /// Trivially relocatable. Copies perform memory allocations; copy will crash
-  /// if `T` is copyable but the complete type is not.
-  vbox(const vbox& that) = delete;
-  vbox& operator=(const vbox& that) = delete;
-  vbox(vbox&& that) requires best::moveable<alloc>;
-  vbox& operator=(vbox&& that) requires best::moveable<alloc>;
-
-  /// # `vbox::vbox(box)`, `vbox::vbox(vbox)`
-  ///
-  /// Wraps a box, virtual or otherwise.
-  template <best::ptr_convertible_to<T> U>
-  explicit vbox(box<U> that)
-    : ptr_(BEST_MOVE(that).leak()), alloc_(that.alloc_) {}
-  template <best::ptr_convertible_to<T> U>
-  explicit vbox(vbox<U> that)
-    : ptr_(BEST_MOVE(that).leak()), alloc_(that.alloc_) {}
-
-  /// # `vbox::vbox(unsafe, ptr)`
-  ///
-  /// Wraps a pointer in a box. This pointer MUST have been allocated using
-  /// the given allocator.
-  explicit vbox(unsafe u, best::vptr<T> ptr) : vbox(u, alloc{}, ptr) {}
-  explicit vbox(unsafe u, alloc alloc, best::vptr<T> ptr)
-    : ptr_(ptr), alloc_(best::in_place, BEST_FWD(alloc)) {}
-
-  /// # `vbox::~vbox()`
-  ///
-  /// Boxes automatically destroy their contents.
-  ~vbox() {
-    if (ptr_.thin() == best::ptr<T>::dangling()) { return; }
-
-    ptr_.destroy();
-    allocator().dealloc(ptr_.raw(), ptr_.layout());
-  }
-
-  /// # `vbox::as_ptr()`
-  ///
-  /// Returns the underlying `best::vptr`.
-  best::vptr<T> as_ptr() const { return ptr_; }
-
-  /// # `vbox::allocator()`
-  ///
-  /// Returns a reference to the box's allocator.
-  const alloc& allocator() const { return *alloc_; }
-  alloc& allocator() { return *alloc_; }
-
-  /// # `vbox::into_raw()`
-  ///
-  /// Explodes this box into its raw parts, and inhibits the destructor. The
-  /// resulting pointer must be freed using the returned allocator at the end of
-  /// the object's lifetime.
-  best::row<best::vptr<T>, alloc> into_raw() && {
-    auto ptr = std::exchange(ptr_, best::ptr<T>::dangling());
-    return {ptr, *BEST_MOVE(alloc_)};
-  }
-
-  /// # `box::leak()`
-  ///
-  /// Disables this `box`'s destructor and returns the pointer. This function
-  /// explicitly leaks memory by withholding the call to `dealloc()`.
-  best::vptr<T> leak() && { return BEST_MOVE(*this).into_raw().first(); }
-
-  /// # `vbox::operator*, vbox::operator->`
-  ///
-  /// Dereferences the box. Note that boxes cannot be null!
-  ///
-  /// Unlike `std::unique_ptr<T>`, dereferencing preserves the constness and
-  /// value category of the box.
-  cref operator*() const& { return *ptr_; }
-  ref operator*() & { return *ptr_; }
-  crref operator*() const&& { return BEST_MOVE(*ptr_); }
-  rref operator*() && { return BEST_MOVE(*ptr_); }
-  cptr operator->() const { return ptr_.operator->(); }
-  ptr operator->() { return ptr_.operator->(); }
-
-  /// # `vbox::copy()`
-  ///
-  /// Makes a copy of the contents of this `box`, if the complete type is
-  /// copyable.
-  best::option<vbox> copy() const requires best::copyable<alloc>
-  {
-    if (!ptr_.is_copyable()) { return best::none; }
-
-    best::vptr<T> ptr(
-      unsafe("the vtable is correct because we're making a copy"),
-      best::ptr(allocator().alloc(ptr_.layout())).cast(best::types<T>),
-      ptr_.vtable());
-    ptr_.copy_to(ptr.raw());
-
-    return vbox(alloc_, ptr);
-  }
-
-  explicit vbox(niche) : ptr_(nullptr) {}
-  bool operator==(niche) const { return ptr_.raw() == nullptr; }
-
- private:
-  best::vptr<T> ptr_;
-  [[no_unique_address]] best::object<alloc> alloc_;
-};
 }  // namespace best
 
 /* ////////////////////////////////////////////////////////////////////////// *\
@@ -500,77 +282,42 @@ class BEST_RELOCATABLE vbox final {
 
 namespace best {
 template <typename T, typename A>
-box<T, A>::box(const box& that)
-  requires best::copyable<T> && best::copyable<alloc>
-  : box(that.allocator(), best::in_place, *that) {}
-
-template <typename T, typename A>
-box<T, A>& box<T, A>::operator=(const box& that) requires best::copyable<T>
-{
-  **this = *that;
-  return *this;
+constexpr box<T, A>::box(const box& that) requires requires(ptr p) {
+  requires best::copyable<alloc>;
+  p.copy(p);
 }
-template <typename T, typename A>
-box<T, A>::box(box&& that) requires best::moveable<alloc>
-  : ptr_(std::exchange(that.ptr_, best::ptr<T>::dangling())),
-    alloc_(BEST_MOVE(that.alloc_)) {}
-
-template <typename T, typename A>
-box<T, A>& box<T, A>::operator=(box&& that) requires best::moveable<alloc>
-{
-  if (best::equal(this, &that)) { return *this; }
-  this->~box();
-  new (this) box(BEST_MOVE(that));
-  return *this;
+  : alloc_(best::in_place, that.allocator()) {
+  ptr_ = {
+    allocator().alloc(that.as_ptr().layout()).cast(best::types<pointee>),
+    that.as_ptr().meta(),
+  };
+  ptr_.copy(that.as_ptr());
 }
 
 template <typename T, typename A>
-box<T[], A>::box(const box& that)
-  requires best::copyable<T> && best::copyable<alloc>
-  : box(that.allocator(), that.as_span()) {}
-template <typename T, typename A>
-box<T[], A>& box<T[], A>::operator=(const box& that) requires best::copyable<T>
+constexpr box<T, A>& box<T, A>::operator=(const box& that)
+  requires requires(ptr p) { p.copy_assign(p); }
 {
-  if (size() == that.size()) {
-    as_span().copy_from(that.as_span());
+  if (layout() != that.layout()) {
+    this->~box();
+    return *new (this) box(that);
   } else {
-    // TODO: It would be nice to try to re-use this allocation when possible.
-    if (data() != best::ptr<T>::dangling()) {
-      as_span().destroy();
-      alloc_->dealloc(data(), best::layout::array<T>(size()));
-    }
-    ptr_ = best::ptr(alloc_->alloc(best::layout::array<T>(that.size())))
-             .cast(best::types<T>);
-    size_ = that.size();
-    as_span().emplace_from(that.as_span());
+    as_ptr().copy_assign(that.as_ptr());
+    return *this;
   }
-  return *this;
 }
 template <typename T, typename A>
-box<T[], A>::box(box&& that) requires best::moveable<alloc>
+constexpr box<T, A>::box(box&& that) requires best::moveable<alloc>
   : ptr_(std::exchange(that.ptr_, best::ptr<T>::dangling())),
-    size_(that.size()),
     alloc_(BEST_MOVE(that.alloc_)) {}
+
 template <typename T, typename A>
-box<T[], A>& box<T[], A>::operator=(box&& that) requires best::moveable<alloc>
+constexpr box<T, A>& box<T, A>::operator=(box&& that)
+  requires best::moveable<alloc>
 {
   if (best::equal(this, &that)) { return *this; }
   this->~box();
-  new (this) box(BEST_MOVE(that));
-  return *this;
-}
-
-template <typename T, typename A>
-vbox<T, A>::vbox(vbox&& that) requires best::moveable<alloc>
-  : ptr_(std::exchange(that.ptr_, best::ptr<T>::dangling())),
-    alloc_(BEST_MOVE(that.alloc_)) {}
-template <typename T, typename A>
-vbox<T, A>& vbox<T, A>::operator=(vbox&& that) requires best::moveable<alloc>
-{
-  if (best::equal(this, &that)) { return *this; }
-  this->~vbox();
-  new (this) vbox(BEST_MOVE(that));
-  return *this;
+  return *new (this) box(BEST_MOVE(that));
 }
 }  // namespace best
 

--- a/best/container/box_test.cc
+++ b/best/container/box_test.cc
@@ -37,48 +37,18 @@ best::test Thin = [](auto& t) {
 };
 
 best::test Span = [](auto& t) {
-  best::box<int[]> x0({1, 2, 3, 4, 5});
-  t.expect_eq(x0.as_span(), best::span{1, 2, 3, 4, 5});
+  best::box x0({1, 2, 3, 4, 5});
+  t.expect_eq(*x0, best::span{1, 2, 3, 4, 5});
 
   best::option<best::box<int[]>> x1;
   t.expect_eq(x1, best::none);
   x1 = x0;
-  t.expect_eq(x1->as_span(), best::span{1, 2, 3, 4, 5});
-  t.expect_eq(x1->as_span(), x0.as_span());
+  t.expect_eq(*x1, best::span{1, 2, 3, 4, 5});
+  t.expect_eq(*x1, *x0);
+  t.expect_eq(x1, x0);
 
   x0 = best::box<int[]>();
-  t.expect_eq(x0.size(), 0);
-};
-
-struct Iface {
-  Iface() = default;
-  Iface(const Iface&) = default;
-  Iface& operator=(const Iface&) = default;
-
-  virtual best::str get() = 0;
-};
-
-class Impl final : public Iface {
- public:
-  explicit Impl(best::strbuf buf) : value_(BEST_MOVE(buf)) {}
-  Impl(const Impl&) = default;
-  Impl& operator=(const Impl&) = default;
-
-  best::str get() override { return value_; }
-
- private:
-  best::strbuf value_;
-};
-
-best::test Virt = [](auto& t) {
-  best::box<Impl> value(Impl{"hello hello hello hello hello"});
-  t.expect_eq(value->get(), "hello hello hello hello hello");
-
-  best::vbox<Iface> virt(BEST_MOVE(value));
-  t.expect_eq(virt->get(), "hello hello hello hello hello");
-
-  best::vbox<Iface> virt2 = *virt.copy();
-  t.expect_eq(virt->get(), "hello hello hello hello hello");
+  t.expect_eq(x0->size(), 0);
 };
 
 best::test Leaky = [](auto& t) {
@@ -100,10 +70,10 @@ best::test Leaky = [](auto& t) {
   x0 = best::box(Bubble());
   x2 = x0;
 
-  best::box<Bubble[]> x3({{}, {}, {}});
+  best::box x3({Bubble{}, {}, {}});
   auto x4 = x3;
   x4 = x3;
   auto x5 = std::move(x3);
-  x4 = best::box<Bubble[]>({{}});
+  x4 = best::box({Bubble{}});
 };
 }  // namespace best::box_test

--- a/best/container/option.h
+++ b/best/container/option.h
@@ -61,6 +61,7 @@ template <typename T>
 concept is_option = requires {
   requires !std::is_class_v<typename best::as_auto<T>::type> ||
              !std::is_abstract_v<typename best::as_auto<T>::type>;
+  requires !std::is_unbounded_array_v<typename best::as_auto<T>::type>;
   requires best::same<best::as_auto<T>,
                       best::option<typename best::as_auto<T>::type>> ||
              requires {

--- a/best/container/vec_test.cc
+++ b/best/container/vec_test.cc
@@ -135,11 +135,11 @@ best::test Append = [](auto& t) {
   t.expect_eq(x2, {"foo", "bar", "baz", "foo", "bar", "baz"});
   x2.splice(2, x2[{.start = 1, .end = 4}]);
   t.expect_eq(x2,
-              {"foo", "bar", "bar", "bar", "bar", "baz", "foo", "bar", "baz"});
+              {"foo", "bar", "bar", "baz", "foo", "baz", "foo", "bar", "baz"});
   x2.truncate(4);
-  t.expect_eq(x2, {"foo", "bar", "bar", "bar"});
+  t.expect_eq(x2, {"foo", "bar", "bar", "baz"});
   x2.splice(0, x2[{.start = 2}]);
-  t.expect_eq(x2, {"bar", "bar", "foo", "bar", "bar", "bar"});
+  t.expect_eq(x2, {"bar", "baz", "foo", "bar", "bar", "baz"});
 };
 
 best::test Leaky = [](auto& t) {

--- a/best/memory/BUILD
+++ b/best/memory/BUILD
@@ -17,6 +17,16 @@ cc_library(
   ],
 )
 
+cc_test(
+  name = "ptr_test",
+  srcs = ["ptr_test.cc"],
+  linkopts = ["-rdynamic"],
+  deps = [
+    ":ptr",
+    "//best/test",
+  ],
+)
+
 cc_library(
   name = "span",
   hdrs = [
@@ -71,6 +81,7 @@ cc_library(
   srcs = ["allocator.cc"],
   deps = [
     ":layout",
+    ":ptr",
     "//best/meta:init",
   ]
 )

--- a/best/memory/allocator.h
+++ b/best/memory/allocator.h
@@ -24,6 +24,7 @@
 #include <cstdlib>
 
 #include "best/memory/layout.h"
+#include "best/memory/ptr.h"
 #include "best/meta/init.h"
 
 //! Low level allocator abstractions.
@@ -46,18 +47,18 @@ namespace best {
 template <typename A>
 concept allocator =  //
   best::moveable<A> && best::equatable<A, A> &&
-  requires(A& alloc, best::layout layout, void* ptr) {
+  requires(A& alloc, best::layout layout, best::ptr<void> ptr) {
     /// # `allocator::alloc(layout)`
     ///
     /// Allocates fresh memory. Returns a non-null pointer to it.
     /// Crashes on allocation failure.
-    { alloc.alloc(layout) } -> std::same_as<void*>;
+    { alloc.alloc(layout) } -> std::same_as<best::ptr<void>>;
 
     /// # `allocator::zalloc(layout)`
     ///
     /// Allocates fresh zeroed memory. Returns a non-null pointer to it.
     /// Crashes on allocation failure.
-    { alloc.zalloc(layout) } -> std::same_as<void*>;
+    { alloc.zalloc(layout) } -> std::same_as<best::ptr<void>>;
 
     /// # `allocator::realloc(ptr, old, new)`
     ///
@@ -67,7 +68,7 @@ concept allocator =  //
     /// The second argument is the original layout it was allocated with, the
     /// third is the desired layout.
     /// Crashes on allocation failure.
-    { alloc.realloc(ptr, layout, layout) } -> std::same_as<void*>;
+    { alloc.realloc(ptr, layout, layout) } -> std::same_as<best::ptr<void>>;
 
     /// # `allocator::dealloc(ptr, layout)`
     ///
@@ -88,10 +89,11 @@ concept allocator =  //
 ///
 /// See `best::allocator` for information on what the functions on this type do.
 struct malloc final {
-  static void* alloc(layout layout);
-  static void* zalloc(layout layout);
-  static void* realloc(void* ptr, layout old, layout layout);
-  static void dealloc(void* ptr, layout layout);
+  static best::ptr<void> alloc(layout layout);
+  static best::ptr<void> zalloc(layout layout);
+  static best::ptr<void> realloc(best::ptr<void> ptr, layout old,
+                                 layout layout);
+  static void dealloc(best::ptr<void> ptr, layout layout);
 
   constexpr bool operator==(const malloc&) const = default;
 };

--- a/best/memory/internal/ptr.h
+++ b/best/memory/internal/ptr.h
@@ -21,7 +21,6 @@
 #define BEST_MEMORY_INTERNAL_PTR_H_
 
 #include <cstddef>
-#include <type_traits>
 
 #include "best/base/hint.h"
 #include "best/base/port.h"
@@ -53,13 +52,16 @@ extern "C" void* memset(void*, int, size_t) noexcept;
 
 // The pointer metadata type for an ordinary object type `T`.
 template <best::is_object T>
-struct object_meta {
+class object_meta {
+ public:
+  using type = T;
   using pointee = T;
   using metadata = best::empty;
+  using as_const = const T;
 
   constexpr object_meta() = default;
   constexpr object_meta(metadata) {}
-  static constexpr metadata to_metadata() { return {}; }
+  constexpr const metadata& to_metadata() const { return m_; }
 
   template <typename P>
   constexpr explicit(
@@ -69,29 +71,52 @@ struct object_meta {
   {}
 
   static constexpr best::layout layout() { return best::layout::of<pointee>(); }
-  static constexpr best::layout stride() { return best::layout::of<pointee>(); }
+  static constexpr auto deref(pointee* ptr) { return ptr; }
 
-  static constexpr object_meta offset(ptrdiff_t offset) { return {}; }
+  static constexpr object_meta meta_for(auto&&...) { return {}; }
+  static constexpr void construct(pointee* dst, bool assign, auto&&... args)
+    requires best::constructible<T, decltype(args)&&...>
+  {
+    if (assign) {
+      if constexpr (best::assignable<T, decltype(args)&&...>) {
+        *dst = (BEST_FWD(args), ...);
+        return;
+      }
+      destroy(dst);
+    }
+    new (dst) T(BEST_FWD(args)...);
+  }
 
-  static constexpr T* deref(pointee* ptr) { return ptr; }
-
-  static constexpr bool copyable() { return best::copyable<T>; }
-  static constexpr void copy(void* dst, pointee* src) {
-    if constexpr (best::copyable<T>) { new (dst) T(*src); }
+  static constexpr bool is_statically_copyable() { return best::copyable<T>; }
+  static constexpr bool is_dynamically_copyable() { return best::copyable<T>; }
+  static constexpr void copy(pointee* dst, pointee* src, bool assign) {
+    if constexpr (best::copyable<T>) {
+      if (assign) {
+        *dst = *src;
+      } else {
+        new (dst) T(*src);
+      }
+    }
   }
 
   static constexpr void destroy(pointee* ptr) { ptr->~T(); }
+
+ private:
+  [[no_unique_address]] best::empty m_;
 };
 
 // The pointer metadata type for a reference or function type.
 template <typename T>
-struct ptr_like_meta {
+class ptr_like_meta {
+ public:
+  using type = T;
   using pointee = best::as_ptr<T> const;
   using metadata = best::empty;
+  using as_const = T;
 
   constexpr ptr_like_meta() = default;
   constexpr ptr_like_meta(metadata) {}
-  static constexpr metadata to_metadata() { return {}; }
+  constexpr const metadata& to_metadata() const { return m_; }
 
   template <typename P>
   constexpr explicit(false /* All ref and function conversions are lossless. */)
@@ -100,29 +125,43 @@ struct ptr_like_meta {
   {}
 
   static constexpr best::layout layout() { return best::layout::of<pointee>(); }
-  static constexpr best::layout stride() { return best::layout::of<pointee>(); }
+  static constexpr auto deref(pointee* ptr) { return *ptr; }
 
-  static constexpr ptr_like_meta offset(ptrdiff_t offset) { return {}; }
+  static constexpr ptr_like_meta meta_for(auto&&...) { return {}; }
+  static constexpr void construct(pointee* dst, bool assign, auto&&... args)
+    requires best::constructible<T, decltype(args)&&...>
+  {
+    if constexpr (best::is_ref<T>) {
+      *const_cast<best::unqual<pointee>*>(dst) = best::addr(args...);
+    } else if constexpr (best::is_func<T>) {
+      *const_cast<best::unqual<pointee>*>(dst) = (args, ...);
+    }
+  }
 
-  static constexpr pointee deref(pointee* ptr) { return *ptr; }
-
-  static constexpr bool copyable() { return true; }
-  static constexpr void copy(void* dst, pointee* src) {
+  static constexpr bool is_statically_copyable() { return true; }
+  static constexpr bool is_dynamically_copyable() { return true; }
+  static constexpr void copy(pointee* dst, pointee* src, bool assign) {
     new (dst) pointee(*src);
   }
 
   static constexpr void destroy(pointee* ptr) {}
+
+ private:
+  [[no_unique_address]] best::empty m_;
 };
 
 // The pointer metadata type for a void type.
 template <best::is_void T>
-struct void_meta {
+class void_meta {
+ public:
+  using type = T;
   using pointee = T;
   using metadata = best::empty;
+  using as_const = const T;
 
   constexpr void_meta() = default;
   constexpr void_meta(metadata) {}
-  static constexpr metadata to_metadata() { return {}; }
+  constexpr const metadata& to_metadata() const { return m_; }
 
   template <typename P>
   constexpr explicit(!best::is_void<typename P::type>)
@@ -131,76 +170,198 @@ struct void_meta {
   {}
 
   static constexpr best::layout layout() { return best::layout::of<void>(); }
-  static constexpr best::layout stride() { return best::layout::of<void>(); }
+  static constexpr auto deref(pointee* ptr) { return ptr; }
 
-  static constexpr void_meta offset(ptrdiff_t offset) { return {}; }
+  static constexpr void_meta meta_for(auto&&...) { return {}; }
+  static constexpr void construct(pointee*, bool, auto&&... args)
+    requires best::constructible<T, decltype(args)&&...>
+  {}
 
-  static constexpr T* deref(pointee* ptr) { return ptr; }
-
-  static constexpr bool copyable() { return true; }
-  static constexpr void copy(void* dst, pointee* src) {}
+  static constexpr bool is_statically_copyable() { return true; }
+  static constexpr bool is_dynamically_copyable() { return true; }
+  static constexpr void copy(pointee* dst, pointee* src, bool assign) {}
 
   static constexpr void destroy(pointee* ptr) {}
+
+ private:
+  [[no_unique_address]] best::empty m_;
+};
+
+template <typename A>
+class array_meta;
+
+template <best::is_object T, size_t len>
+class array_meta<T[len]> {
+ public:
+  using type = T[len];
+  using pointee = T[len];
+  using metadata = best::empty;
+  using as_const = const T[len];
+
+  constexpr array_meta() = default;
+  constexpr array_meta(metadata) {}
+  constexpr const metadata& to_metadata() const { return m_; }
+
+  template <typename P>
+  constexpr explicit(
+    !best::same<best::unqual<typename P::type>, best::unqual<T>>)
+    array_meta(best::tlist<P>, const typename P::metadata&)
+      requires best::convertible<pointee*, typename P::pointee*>
+  {}
+
+  static constexpr best::layout layout() { return best::layout::of<T[len]>(); }
+  // TODO: Switch view types. Doing this properly will unfortunately require
+  // cooking up some way to do `best::span<T&&>` or such.
+  //
+  // constexpr best::span<T, len> deref(pointee* ptr) const {
+  //   return best::span<T, len>{std::data(*ptr), len};
+  // }
+  static constexpr pointee* deref(pointee* ptr) { return ptr; }
+
+  static constexpr array_meta meta_for(auto&&...) { return {}; }
+  template <typename U>
+  constexpr void construct(pointee* dst, bool assign,
+                           best::span<U, len> s) const
+    requires best::constructible<T, U&>
+  {
+    for (size_t i = 0; i < len; ++i) {
+      best::ptr next = best::addr((*dst)[i]);
+      if (assign) {
+        next.assign(s.data()[i]);
+      } else {
+        next.construct(s.data()[i]);
+      }
+    }
+  }
+  template <typename U>
+  constexpr void construct(pointee* dst, bool assign, U (&s)[len]) const
+    requires best::constructible<T, U&>
+  {
+    for (size_t i = 0; i < len; ++i) {
+      best::ptr next = best::addr((*dst)[i]);
+      if (assign) {
+        next.assign(s[i]);
+      } else {
+        next.construct(s[i]);
+      }
+    }
+  }
+  template <typename U>
+  constexpr void construct(pointee* dst, bool assign, U (&&s)[len]) const
+    requires best::constructible<T, U&>
+  {
+    for (size_t i = 0; i < len; ++i) {
+      best::ptr next = best::addr((*dst)[i]);
+      if (assign) {
+        next.assign(BEST_MOVE(s[i]));
+      } else {
+        next.construct(BEST_MOVE(s[i]));
+      }
+    }
+  }
+
+  static constexpr bool is_statically_copyable() { return best::copyable<T>; }
+  static constexpr bool is_dynamically_copyable() { return best::copyable<T>; }
+  constexpr void copy(pointee* dst, pointee* src, bool assign) const {
+    if constexpr (best::copyable<T>) { construct(dst, assign, *src); }
+  }
+
+  constexpr void destroy(pointee* ptr) const {
+    for (size_t i = 0; i < len; ++i) { (*ptr)[i].~T(); }
+  }
+
+ private:
+  [[no_unique_address]] best::empty m_;
 };
 
 /// The pointer metadata for an unbounded array type `T[]`.
 template <best::is_object T>
-struct unbounded_meta {
+class array_meta<T[]> {
+ public:
+  using type = T[];
   using pointee = T;
   using metadata = size_t;
+  using as_const = const T[];
 
-  constexpr unbounded_meta(size_t len) : len(len) {}
-  constexpr size_t to_metadata() const { return len; }
+  constexpr array_meta() = default;
+  constexpr array_meta(metadata len) : len_(len) {}
+  constexpr const metadata& to_metadata() const { return len_; }
 
-  template <best::qualifies_to<T> U, size_t n>
-  constexpr unbounded_meta(best::tlist<U>, const best::empty&)
-    : len(size_of<U>) {}
-  template <best::qualifies_to<T> U, size_t n>
-  constexpr unbounded_meta(best::tlist<std::array<U, n>>, const best::empty&)
-    : len(n * size_of<U>) {}
-  template <best::qualifies_to<T> U, size_t n>
-  constexpr unbounded_meta(best::tlist<U[n]>, const best::empty&)
-    : len(n * size_of<U>) {}
   template <best::qualifies_to<T> U>
-  constexpr unbounded_meta(best::tlist<U[]>, const size_t& n) : len(n) {}
+  constexpr array_meta(best::tlist<best::ptr<U>>, const auto&)
+    requires (best::ptr<U>::is_thin())
+    : len_(1) {}
+  template <best::qualifies_to<T> U, size_t n>
+  constexpr array_meta(best::tlist<best::ptr<std::array<U, n>>>,
+                       const best::empty&)
+    : len_(n) {}
+  template <best::qualifies_to<T> U, size_t n>
+  constexpr array_meta(best::tlist<best::ptr<U[n]>>, const best::empty&)
+    : len_(n) {}
+  template <best::qualifies_to<T> U>
+  constexpr array_meta(best::tlist<best::ptr<U[]>>, const size_t& n)
+    : len_(n) {}
 
-  constexpr best::layout layout() const { return best::layout::array<T>(len); }
-  static best::layout stride() { return best::layout::of<T>(); }
+  constexpr best::layout layout() const { return best::layout::array<T>(len_); }
+  constexpr best::span<T> deref(pointee* ptr) const { return {ptr, len_}; }
 
-  constexpr unbounded_meta offset(ptrdiff_t offset) { return len - offset; }
+  static constexpr array_meta meta_for() { return 0; }
+  constexpr void construct(pointee* dst, bool assign) const {}
 
-  constexpr best::span<T> deref(pointee* ptr) const { return {ptr, len}; }
+  static constexpr array_meta meta_for(auto&& s) { return s.size(); }
+  template <typename U>
+  constexpr void construct(pointee* dst, bool assign, best::span<U> s) const
+    requires best::constructible<T, U&>
+  {
+    if (assign) {
+      deref(dst).copy_from(s);
+    } else {
+      deref(dst).emplace_from(s);
+    }
+  }
+  template <typename U>
+  constexpr void construct(pointee* dst, bool assign,
+                           std::initializer_list<U> s) const
+    requires best::constructible<T, U&>
+  {
+    construct(dst, assign, best::span<const U>(s));
+  }
 
-  static constexpr bool copyable() { return best::copyable<T>; }
-  void copy(void* dst, pointee* src) const {
-    // This is not constexpr... :/
-    for (size_t i = 0; i < len; ++i) {
-      new (dst) T(src[i]);
-      dst = static_cast<const char*>(dst) + best::size_of<T>;
+  static constexpr bool is_statically_copyable() { return best::copyable<T>; }
+  static constexpr bool is_dynamically_copyable() { return best::copyable<T>; }
+  constexpr void copy(pointee* dst, pointee* src, bool assign) const {
+    if constexpr (best::copyable<T>) {
+      construct(dst, assign, best::span{src, len_});
     }
   }
 
   constexpr void destroy(pointee* ptr) const {
-    for (size_t i = 0; i < len; ++i) { ptr[i].~T(); }
+    for (size_t i = 0; i < len_; ++i) { ptr[i].~T(); }
   }
 
-  size_t len = 0;
+ private:
+  size_t len_ = 0;
+};
+
+struct access {
+  template <typename T>
+  static auto get_meta() {
+    if constexpr (requires { typename T::BestPtrMetadata; }) {
+      return best::id<typename T::BestPtrMetadata>{};
+    } else if constexpr (best::is_array<T>) {
+      return best::id<array_meta<T>>{};
+    } else if constexpr (best::is_object<T>) {
+      return best::id<object_meta<T>>{};
+    } else if constexpr (best::is_void<T>) {
+      return best::id<void_meta<T>>{};
+    } else {
+      return best::id<ptr_like_meta<T>>{};
+    }
+  }
 };
 
 template <typename T>
-using meta = decltype([] {
-  if constexpr (requires { typename T::BestPtrMetadata; }) {
-    return best::id<typename T::BestPtrMetadata>{};
-  } else if constexpr (std::is_unbounded_array_v<T>) {
-    return best::id<unbounded_meta<T>>{};
-  } else if constexpr (best::is_object<T>) {
-    return best::id<object_meta<T>>{};
-  } else if constexpr (best::is_void<T>) {
-    return best::id<void_meta<T>>{};
-  } else {
-    return best::id<ptr_like_meta<T>>{};
-  }
-}())::type;
+using meta = decltype(access::get_meta<T>())::type;
 
 }  // namespace best::ptr_internal
 

--- a/best/memory/internal/ptr.h
+++ b/best/memory/internal/ptr.h
@@ -21,9 +21,14 @@
 #define BEST_MEMORY_INTERNAL_PTR_H_
 
 #include <cstddef>
+#include <type_traits>
 
 #include "best/base/hint.h"
 #include "best/base/port.h"
+#include "best/memory/layout.h"
+#include "best/meta/empty.h"
+#include "best/meta/init.h"
+#include "best/meta/taxonomy.h"
 
 #define BEST_CONSTEXPR_MEMCPY_ BEST_HAS_FEATURE(cxx_constexpr_string_builtins)
 
@@ -45,6 +50,158 @@ void* memmove(void*, const void*, size_t) noexcept;
 #endif
 
 extern "C" void* memset(void*, int, size_t) noexcept;
+
+// The pointer metadata type for an ordinary object type `T`.
+template <best::is_object T>
+struct object_meta {
+  using pointee = T;
+  using metadata = best::empty;
+
+  constexpr object_meta() = default;
+  constexpr object_meta(metadata) {}
+  static constexpr metadata to_metadata() { return {}; }
+
+  template <typename P>
+  constexpr explicit(
+    !best::same<best::unqual<typename P::type>, best::unqual<T>>)
+    object_meta(best::tlist<P>, const typename P::metadata&)
+      requires best::convertible<pointee*, typename P::pointee*>
+  {}
+
+  static constexpr best::layout layout() { return best::layout::of<pointee>(); }
+  static constexpr best::layout stride() { return best::layout::of<pointee>(); }
+
+  static constexpr object_meta offset(ptrdiff_t offset) { return {}; }
+
+  static constexpr T* deref(pointee* ptr) { return ptr; }
+
+  static constexpr bool copyable() { return best::copyable<T>; }
+  static constexpr void copy(void* dst, pointee* src) {
+    if constexpr (best::copyable<T>) { new (dst) T(*src); }
+  }
+
+  static constexpr void destroy(pointee* ptr) { ptr->~T(); }
+};
+
+// The pointer metadata type for a reference or function type.
+template <typename T>
+struct ptr_like_meta {
+  using pointee = best::as_ptr<T> const;
+  using metadata = best::empty;
+
+  constexpr ptr_like_meta() = default;
+  constexpr ptr_like_meta(metadata) {}
+  static constexpr metadata to_metadata() { return {}; }
+
+  template <typename P>
+  constexpr explicit(false /* All ref and function conversions are lossless. */)
+    ptr_like_meta(best::tlist<P>, const typename P::metadata&)
+      requires best::convertible<pointee*, typename P::pointee*>
+  {}
+
+  static constexpr best::layout layout() { return best::layout::of<pointee>(); }
+  static constexpr best::layout stride() { return best::layout::of<pointee>(); }
+
+  static constexpr ptr_like_meta offset(ptrdiff_t offset) { return {}; }
+
+  static constexpr pointee deref(pointee* ptr) { return *ptr; }
+
+  static constexpr bool copyable() { return true; }
+  static constexpr void copy(void* dst, pointee* src) {
+    new (dst) pointee(*src);
+  }
+
+  static constexpr void destroy(pointee* ptr) {}
+};
+
+// The pointer metadata type for a void type.
+template <best::is_void T>
+struct void_meta {
+  using pointee = T;
+  using metadata = best::empty;
+
+  constexpr void_meta() = default;
+  constexpr void_meta(metadata) {}
+  static constexpr metadata to_metadata() { return {}; }
+
+  template <typename P>
+  constexpr explicit(!best::is_void<typename P::type>)
+    void_meta(best::tlist<P>, const typename P::metadata&)
+      requires best::convertible<pointee*, typename P::pointee*>
+  {}
+
+  static constexpr best::layout layout() { return best::layout::of<void>(); }
+  static constexpr best::layout stride() { return best::layout::of<void>(); }
+
+  static constexpr void_meta offset(ptrdiff_t offset) { return {}; }
+
+  static constexpr T* deref(pointee* ptr) { return ptr; }
+
+  static constexpr bool copyable() { return true; }
+  static constexpr void copy(void* dst, pointee* src) {}
+
+  static constexpr void destroy(pointee* ptr) {}
+};
+
+/// The pointer metadata for an unbounded array type `T[]`.
+template <best::is_object T>
+struct unbounded_meta {
+  using pointee = T;
+  using metadata = size_t;
+
+  constexpr unbounded_meta(size_t len) : len(len) {}
+  constexpr size_t to_metadata() const { return len; }
+
+  template <best::qualifies_to<T> U, size_t n>
+  constexpr unbounded_meta(best::tlist<U>, const best::empty&)
+    : len(size_of<U>) {}
+  template <best::qualifies_to<T> U, size_t n>
+  constexpr unbounded_meta(best::tlist<std::array<U, n>>, const best::empty&)
+    : len(n * size_of<U>) {}
+  template <best::qualifies_to<T> U, size_t n>
+  constexpr unbounded_meta(best::tlist<U[n]>, const best::empty&)
+    : len(n * size_of<U>) {}
+  template <best::qualifies_to<T> U>
+  constexpr unbounded_meta(best::tlist<U[]>, const size_t& n) : len(n) {}
+
+  constexpr best::layout layout() const { return best::layout::array<T>(len); }
+  static best::layout stride() { return best::layout::of<T>(); }
+
+  constexpr unbounded_meta offset(ptrdiff_t offset) { return len - offset; }
+
+  constexpr best::span<T> deref(pointee* ptr) const { return {ptr, len}; }
+
+  static constexpr bool copyable() { return best::copyable<T>; }
+  void copy(void* dst, pointee* src) const {
+    // This is not constexpr... :/
+    for (size_t i = 0; i < len; ++i) {
+      new (dst) T(src[i]);
+      dst = static_cast<const char*>(dst) + best::size_of<T>;
+    }
+  }
+
+  constexpr void destroy(pointee* ptr) const {
+    for (size_t i = 0; i < len; ++i) { ptr[i].~T(); }
+  }
+
+  size_t len = 0;
+};
+
+template <typename T>
+using meta = decltype([] {
+  if constexpr (requires { typename T::BestPtrMetadata; }) {
+    return best::id<typename T::BestPtrMetadata>{};
+  } else if constexpr (std::is_unbounded_array_v<T>) {
+    return best::id<unbounded_meta<T>>{};
+  } else if constexpr (best::is_object<T>) {
+    return best::id<object_meta<T>>{};
+  } else if constexpr (best::is_void<T>) {
+    return best::id<void_meta<T>>{};
+  } else {
+    return best::id<ptr_like_meta<T>>{};
+  }
+}())::type;
+
 }  // namespace best::ptr_internal
 
 #endif  // BEST_MEMORY_INTERNAL_PTR_H_

--- a/best/memory/layout.h
+++ b/best/memory/layout.h
@@ -68,7 +68,7 @@ class layout final {
   /// This must observe two critical requirements: `size % align == 0`, and
   /// `best::is_pow2(align)`.
   constexpr explicit layout(unsafe, size_t size, size_t align)
-      : BEST_LAYOUT_SIZE_(size), BEST_LAYOUT_ALIGN_(align) {}
+    : BEST_LAYOUT_SIZE_(size), BEST_LAYOUT_ALIGN_(align) {}
 
   /// # `layout::of<T>()`
   ///
@@ -188,12 +188,12 @@ struct laid_out final {
   /// # `laid_out::layout()`
   ///
   /// Returns the block's layout.
-  constexpr static best::layout layout() { return l; }
+  static constexpr best::layout layout() { return l; }
 
  private:
   alignas(layout().align()) [[no_unique_address]] best::select<
-      l.size() == 0, best::empty,
-      char[layout().size() + (layout().size() == 0)]> data_;
+    l.size() == 0, best::empty,
+    char[layout().size() + (layout().size() == 0)]> data_;
 };
 }  // namespace best
 

--- a/best/memory/ptr_test.cc
+++ b/best/memory/ptr_test.cc
@@ -1,0 +1,147 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#include "best/memory/ptr.h"
+
+#include "best/meta/init.h"
+#include "best/test/test.h"
+
+namespace best::ptr_test {
+
+static_assert(best::is_thin<int>);
+static_assert(best::is_thin<const int>);
+static_assert(best::is_thin<int&>);
+static_assert(best::is_thin<const int&>);
+static_assert(best::is_thin<void>);
+static_assert(best::is_thin<const void>);
+static_assert(best::is_thin<int[5]>);
+static_assert(best::is_thin<const int[5]>);
+static_assert(!best::is_thin<int[]>);
+static_assert(!best::is_thin<const int[]>);
+
+template <typename T>
+concept is_const = best::ptr<T>::is_const();
+static_assert(!is_const<int>);
+static_assert(is_const<const int>);
+static_assert(is_const<int&>);  // Intentional!
+static_assert(is_const<const int&>);
+static_assert(!is_const<void>);
+static_assert(is_const<const void>);
+static_assert(!is_const<int[5]>);
+static_assert(is_const<const int[5]>);
+static_assert(!is_const<int[]>);
+static_assert(is_const<const int[]>);
+
+best::test Null = [](auto& t) {
+  best::ptr<int> x0;
+  best::ptr<int> x1 = nullptr;
+
+  t.expect_eq(x0, nullptr);
+  t.expect_eq(x1, nullptr);
+
+  best::ptr<int[]> x2;
+  best::ptr<int[]> x3 = nullptr;
+
+  t.expect_eq(x2, nullptr);
+  t.expect_eq(x3, nullptr);
+};
+
+best::test FromRaw = [](auto& t) {
+  int x = 5;
+  best::ptr<int> x0 = &x;
+  t.expect_eq(x0, &x);
+  t.expect_eq(&*x0, &x);
+  t.expect_eq(x0.get(), &x);
+  t.expect_eq(*x0, 5);
+  t.expect_eq(x0.deref(), 5);
+  t.expect_eq(*x0 = 42, 42);
+  t.expect_eq(x, 42);
+
+  best::ptr<const int> x1 = x0.as_const();
+  t.expect_eq(x1, &x);
+  t.expect_eq(&*x1, &x);
+  t.expect_eq(x1.get(), &x);
+  t.expect_eq(*x1, 42);
+  t.expect_eq(x1.deref(), 42);
+
+  t.expect_eq(x0, x1);
+
+  best::ptr<int&> x2 = &x0.raw();
+  t.expect_eq(x2, &x0.raw());
+  t.expect_eq(&*x0, &x);
+  t.expect_eq(x0.get(), &x);
+  t.expect_eq(*x0, 42);
+  t.expect_eq(x0.deref(), 42);
+  t.expect_eq(++*x0, 43);
+  t.expect_eq(x, 43);
+
+  best::ptr<void> x3 = &x2;
+  t.expect_eq(x3, &x2);
+  t.expect_eq(x3.get(), &x2);
+};
+
+template <typename From, typename To>
+concept conv = best::convertible<best::ptr<To>, best::ptr<From>>;
+
+static_assert(conv<int, int>);
+static_assert(conv<int, const int>);
+static_assert(conv<const int, const int>);
+static_assert(conv<int, volatile int>);
+static_assert(!conv<const int, int>);
+static_assert(!conv<int, unsigned>);
+static_assert(conv<int, void>);
+static_assert(conv<int, const void>);
+static_assert(!conv<const int, void>);
+static_assert(conv<int&, const int&>);
+static_assert(!conv<const int&, int&>);
+static_assert(conv<int&, int* const>);
+static_assert(conv<int*, int&>);
+static_assert(conv<int&, int&&>);
+static_assert(conv<int&&, int&>);
+static_assert(conv<int(), int (*const)()>);
+static_assert(conv<int (*const)(), int()>);
+
+struct Base {};
+struct Derived : Base {};
+
+static_assert(conv<Derived, Base>);
+static_assert(!conv<Base, Derived>);
+
+static_assert(conv<int[4], const int[4]>);
+static_assert(!conv<const int[4], int[4]>);
+static_assert(conv<int[4], int[]>);
+static_assert(conv<const int[4], const int[]>);
+static_assert(!conv<const int[4], int[]>);
+static_assert(conv<int, int[]>);
+static_assert(conv<const int, const int[]>);
+static_assert(!conv<const int, int[]>);
+
+best::test Span = [](auto& t) {
+  int xs[] = {1, 2, 3, 4, 5};
+  best::ptr<int[5]> x0 = &xs;
+  // t.expect_eq(x0->size(), 5);
+
+  best::ptr<int[]> x1 = x0;
+  t.expect_eq(x1->size(), 5);
+
+  best::ptr<int[]> x2 = best::ptr(&(*x0)[1]);
+  t.expect_eq(x2->size(), 1);
+};
+
+}  // namespace best::ptr_test

--- a/best/meta/init.h
+++ b/best/meta/init.h
@@ -25,6 +25,7 @@
 #include <type_traits>
 
 #include "best/meta/internal/init.h"
+#include "best/meta/taxonomy.h"
 
 //! Concepts for determining when a type can be initialized in a particular
 //! way.
@@ -181,9 +182,13 @@ concept relocatable =
 template <typename T, typename... Args>
 concept destructible =
   init_internal::only_trivial<Args...> &&  //
-  (!std::is_object_v<T> ||
-   (init_internal::is_trivial<Args...> ? std::is_trivially_destructible_v<T>
-                                       : std::is_destructible_v<T>));
+  (best::is_unbounded_array<T>
+     ? (init_internal::is_trivial<Args...>
+          ? std::is_trivially_destructible_v<best::unarray<T>>
+          : std::is_destructible_v<best::unarray<T>>)
+     : (!std::is_object_v<T> || (init_internal::is_trivial<Args...>
+                                   ? std::is_trivially_destructible_v<T>
+                                   : std::is_destructible_v<T>)));
 
 /// A callback that constructs a `T`.
 ///

--- a/best/meta/taxonomy.h
+++ b/best/meta/taxonomy.h
@@ -346,7 +346,20 @@ concept static_derives = requires(Base* base) {
 /// Checks whether `T` statically derives `Base`.
 template <typename T, typename Base>
 concept virtual_derives =
-    best::derives<T, Base> && !best::static_derives<T, Base>;
+  best::derives<T, Base> && !best::static_derives<T, Base>;
+
+template <typename T>
+concept is_array = std::is_array_v<T>;
+
+template <typename T, size_t n = -1>
+concept is_bounded_array =
+  std::is_bounded_array_v<T> && (n == -1 || n == std::extent_v<T>);
+
+template <typename T>
+concept is_unbounded_array = std::is_unbounded_array_v<T>;
+
+template <typename T>
+using unarray = std::remove_extent_t<T>;
 }  // namespace best
 
 #endif  // BEST_META_TAXONOMY_H_

--- a/best/meta/taxonomy.h
+++ b/best/meta/taxonomy.h
@@ -292,6 +292,61 @@ concept is_struct = std::is_class_v<T> && std::is_aggregate_v<T>;
 /// Identifies an enumeration type.
 template <typename T>
 concept is_enum = std::is_enum_v<T>;
+
+/// # `best::is_virtual`
+///
+/// Identifies a virtual (polymorphic) type: one which declares or inherits
+/// at least one virtual function or base.
+template <typename T>
+concept is_virtual = std::is_polymorphic_v<T>;
+
+/// # `best::is_abstract`
+///
+/// Identifies an abstract type: one which declares or inherits at least one
+/// pure virtual function.
+template <typename T>
+concept is_abstract = best::is_virtual<T> && std::is_abstract_v<T>;
+
+/// # `best::is_concrete`
+///
+/// Identifies a concrete type: one which is not abstract.
+template <typename T>
+concept is_concrete = !best::is_abstract<T>;
+
+/// # `best::is_open`
+///
+/// Identifies a type that can be used as a base class.
+template <typename T>
+concept is_open = std::is_final_v<T> && std::is_class_v<T>;
+
+/// # `best::is_final`
+///
+/// Identifies a type that cannot be used as a base class. This includes both
+/// `final` class types and non-class types.
+template <typename T>
+concept is_final = !std::is_final_v<T>;
+
+/// # `best::derives`
+///
+/// Checks whether `T` derives `Base`.
+template <typename T, typename Base>
+concept derives = std::is_base_of_v<Base, T>;
+
+/// # `best::static_derives`
+///
+/// Checks whether `T` statically derives `Base`.
+template <typename T, typename Base>
+concept static_derives = requires(Base* base) {
+  requires best::derives<T, Base>;
+  static_cast<T*>(base);
+};
+
+/// # `best::virtual_derives`
+///
+/// Checks whether `T` statically derives `Base`.
+template <typename T, typename Base>
+concept virtual_derives =
+    best::derives<T, Base> && !best::static_derives<T, Base>;
 }  // namespace best
 
 #endif  // BEST_META_TAXONOMY_H_

--- a/best/meta/tlist.h
+++ b/best/meta/tlist.h
@@ -310,13 +310,15 @@ class tlist final {
   /// Returns the first index of this list that satisfies the given type
   /// predicate. This predicate can be a callback (as in `map()`), a bool-typed
   /// value trait, or a type/value to search for.
-  static constexpr auto find(tlist_internal::t_callable<Elems...> auto pred) {
+  static constexpr auto find(tlist_internal::t_callable<Elems...> auto&& pred) {
     size_t n = -1;
-    if (((++n, best::call<Elems>(pred)) || ...)) { return opt_size(n); }
+    if (((++n, best::call<Elems>(BEST_FWD(pred))) || ...)) {
+      return opt_size(n);
+    }
     return opt_size{};
   }
-  static constexpr auto find(tlist_internal::v_callable<Elems...> auto pred) {
-    return find([&]<typename V> { return best::call(pred, V{}); });
+  static constexpr auto find(tlist_internal::v_callable<Elems...> auto&& pred) {
+    return find([&]<typename V> { return best::call(BEST_FWD(pred), V{}); });
   }
   template <typename T>
   static constexpr auto find() {

--- a/best/text/internal/format_parser.h
+++ b/best/text/internal/format_parser.h
@@ -262,7 +262,8 @@ template <typename spec>
 constexpr bool validate(best::span<const typename spec::query> queries,
                         best::span<const char> templ) {
   return format_internal::visit_template<spec>(
-    templ.data(), templ.size() - 1, nullptr, [&](size_t n, const spec& s) {
+    templ.data().raw(), templ.size() - 1, nullptr,
+    [&](size_t n, const spec& s) {
       if (n > queries.size()) { return false; }
       auto& q = queries[n];
 
@@ -281,6 +282,8 @@ class templ final {
     spec::query::template of<Args>...};
 
  public:
+  static_assert(validate<spec>(Queries, ""));
+
   template <size_t n>
   constexpr templ(const char (&chars)[n], best::location loc = best::here)
     BEST_IS_VALID_LITERAL(chars, utf8{})

--- a/best/text/str.h
+++ b/best/text/str.h
@@ -512,7 +512,7 @@ class pretext final {
   ///
   /// Returns the string's data pointer.
   /// This value is never null.
-  constexpr const code* data() const { return span_.data(); }
+  constexpr const code* data() const { return span_.data().raw(); }
 
   /// # `pretext::is_empty()`
   ///

--- a/best/text/strbuf.h
+++ b/best/text/strbuf.h
@@ -193,8 +193,8 @@ class textbuf final {
   ///
   /// Returns the string's data pointer.
   /// This value is never null.
-  const code* data() const { return buf_.data(); }
-  code* data() { return buf_.data(); }
+  const code* data() const { return buf_.data().raw(); }
+  code* data() { return buf_.data().raw(); }
 
   /// # `textbuf::size()`
   ///

--- a/best/text/utf16.h
+++ b/best/text/utf16.h
@@ -56,7 +56,7 @@ struct utf16 final {
   static constexpr best::result<void, encoding_error> encode(
     best::span<char16_t>* output, rune rune) {
     auto size =
-      best::utf_internal::encode16(output->data(), output->size(), rune);
+      best::utf_internal::encode16(output->data().raw(), output->size(), rune);
     if (size < 0) { return encoding_error(~size); }
 
     *output = (*output)[{.start = size}];
@@ -68,7 +68,7 @@ struct utf16 final {
     auto words = best::utf_internal::decode16_size(*input);
     if (words < 0) { return encoding_error(~words); }
 
-    auto code = best::utf_internal::decode16(input->data(), words);
+    auto code = best::utf_internal::decode16(input->data().raw(), words);
     if (code < 0) { return encoding_error(~code); }
 
     *input = (*input)[{.start = words}];

--- a/best/text/utf8.h
+++ b/best/text/utf8.h
@@ -46,7 +46,8 @@ struct utf8 final {
   };
 
   static constexpr bool validate(best::span<const char> input) {
-    return best::utf_internal::validate_utf8_fast(input.data(), input.size());
+    return best::utf_internal::validate_utf8_fast(input.data().raw(),
+                                                  input.size());
   }
 
   static constexpr bool is_boundary(best::span<const char> input, size_t idx) {
@@ -59,7 +60,7 @@ struct utf8 final {
     best::span<char>* output, rune rune) {
     size_t bytes = best::utf_internal::encode8_size(rune);
     if (output->size() < bytes) { return encoding_error::OutOfBounds; }
-    best::utf_internal::encode8(output->data(), rune, bytes);
+    best::utf_internal::encode8(output->data().raw(), rune, bytes);
 
     *output = (*output)[{.start = bytes}];
     return best::ok();
@@ -70,7 +71,7 @@ struct utf8 final {
     auto bytes = best::utf_internal::decode8_size(*input);
     if (bytes < 0) { return encoding_error(~bytes); }
 
-    auto code = best::utf_internal::decode8(input->data(), bytes);
+    auto code = best::utf_internal::decode8(input->data().raw(), bytes);
     if (code < 0) { return encoding_error(~code); }
 
     // Elide a bounds check here; this shaves off milliseconds off of the
@@ -122,7 +123,7 @@ struct wtf8 final {
     auto bytes = best::utf_internal::decode8_size(*input);
     if (bytes < 0) { return encoding_error(~bytes); }
 
-    auto code = best::utf_internal::decode8(input->data(), bytes);
+    auto code = best::utf_internal::decode8(input->data().raw(), bytes);
     if (code < 0) { return encoding_error(~code); }
 
     // Elide a bounds check here; this shaves off milliseconds off of the


### PR DESCRIPTION
This is the first in a series of PRs to fix some flaws in `best`'s object model. This patch removes `best::vptr` and `best::vbox`, and unifies `best::ptr<T>` and `best:;ptr<T[]>` using a Rust-like pointer metadata system.

Unfortunately, this uncovered a bunch of gross issues with several core components, including handling of arrays, the construction concepts, containers like `best::object`, and the fact there is no rvalue span. In the sequel, I'll reorganize all of the type traits and concepts.