### PR TITLE
Implement multi-interface `best::dyn`s

### DIFF
--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -112,9 +112,10 @@ template <typename>
 class track_location;
 
 // best/memory/dyn.h
-template <typename I>
-requires requires { typename I::BestFuncs; }
-class vtable;
+template <typename>
+class interface_base;
+template <typename...>
+class itable;
 
 // best/memory/ptr.h
 template <typename>

--- a/best/container/box.h
+++ b/best/container/box.h
@@ -299,8 +299,8 @@ box(std::initializer_list<T>) -> box<T[]>;
 /// # `best::dynbox<I>`
 ///
 /// A shorthand for a box containing a `best::dyn`.
-template <best::interface I, typename A = best::malloc>
-using dynbox = best::box<best::dyn<I>, A>;
+template <best::interface... Interfaces>
+using dynbox = best::box<best::dyn<Interfaces...>>;
 }  // namespace best
 
 /* ////////////////////////////////////////////////////////////////////////// *\

--- a/best/container/row.h
+++ b/best/container/row.h
@@ -577,25 +577,27 @@ constexpr auto row<A...>::as_args() && {
 
 template <typename... A>
 constexpr best::row<best::as_ref<const A>...> row<A...>::as_ref() const& {
-  apply([](auto&&... args) {
-    best::row<best::as_ref<const A>...>(BEST_FWD(args)...);
+  return apply([](auto&&... args) {
+    return best::row<best::as_ref<const A>...>(BEST_FWD(args)...);
   });
 }
 template <typename... A>
 constexpr best::row<best::as_ref<A>...> row<A...>::as_ref() & {
-  apply(
-    [](auto&&... args) { best::row<best::as_ref<A>...>(BEST_FWD(args)...); });
+  return apply([](auto&&... args) {
+    return best::row<best::as_ref<A>...>(BEST_FWD(args)...);
+  });
 }
 template <typename... A>
 constexpr best::row<best::as_rref<const A>...> row<A...>::as_ref() const&& {
-  BEST_MOVE(*this).apply([](auto&&... args) {
-    best::row<best::as_rref<const A>...>(BEST_FWD(args)...);
+  return BEST_MOVE(*this).apply([](auto&&... args) {
+    return best::row<best::as_rref<const A>...>(BEST_FWD(args)...);
   });
 }
 template <typename... A>
 constexpr best::row<best::as_rref<A>...> row<A...>::as_ref() && {
-  BEST_MOVE(*this).apply(
-    [](auto&&... args) { best::row<best::as_rref<A>...>(BEST_FWD(args)...); });
+  return BEST_MOVE(*this).apply([](auto&&... args) {
+    return best::row<best::as_rref<A>...>(BEST_FWD(args)...);
+  });
 }
 
 template <typename... A>

--- a/best/func/dyn.h
+++ b/best/func/dyn.h
@@ -23,32 +23,92 @@
 #include <cstddef>
 
 #include "best/base/access.h"
+#include "best/func/arrow.h"
 #include "best/func/internal/dyn.h"
 #include "best/memory/layout.h"
 #include "best/memory/ptr.h"
-#include "best/meta/init.h"
+#include "best/meta/tlist.h"
 #include "best/meta/traits/ptrs.h"
 #include "best/meta/traits/quals.h"
 #include "best/meta/traits/refs.h"
 
 namespace best {
-template <typename T, typename I>
-void BestImplements(T*, I*) = delete;
+/// # `best::interface<I>`
+///
+/// Whether `I` is an interface type usable with `best::dyn<I>`. Such a type
+/// is a class with the following interface:
+///
+/// ```
+/// class MyIface final : public best::interface_base<MyIface> {
+///  public:
+///   friend best::access;
+///
+///   struct BestVtable {
+///     // ...
+///   };
+///
+///  private:
+///   constexpr my_iface(void* data, const BestVtable* vt)
+///     : data_(data), vt_(vt) {}
+///
+///   void* data_;
+///   const BestVtable* vt_;
+/// };
+/// ```
+///
+/// In other words, it must have a member type named `BestVtable`, and it must
+/// be privately constructible from a const pointer to one.
+///
+/// The class is expected to define member functions that call function pointers
+/// stored in in `vtable().funcs`. The `BEST_INTERFACE()` macro can be used to
+/// ease implementing such boilerplate.
+template <typename Interface>
+concept interface = requires {
+  typename best::as_auto<Interface>::BestVtable;
+  requires best::derives<Interface,
+                         best::interface_base<best::as_auto<Interface>>>;
+  requires best::dyn_internal::access::can_wrap<Interface>();
+};
+
+/// # `best::implements<T, I>`
+///
+/// Checks whether a type implements the given interface type. To implement it,
+/// the FTADLE `BestImplements(T&, I*)` must be findable by ADL. This function
+/// must return an appropriate vtable type.
+///
+/// Both arguments actually passed to `BestImplements` will be null.
+template <typename T, typename Interface>
+concept implements = requires {
+  // Force this constraint to resolve before we name best::vtable to avoid a
+  // requirement cycle. This might be a clang bug, but concepts are so
+  // impossible to understand it might also be nominal. :)
+  typename best::as_auto<Interface>::BestVtable;
+
+  {
+    BestImplements((best::as_raw_ptr<T>)nullptr,
+                   (best::as_auto<Interface>*)nullptr)
+  } -> best::same<typename best::as_auto<Interface>::BestVtable>;
+};
 
 /// # `best::vtable`
 ///
-/// A complete, raw vtable for a `best::dyn`. This includes a custom
-/// per-interface function pointer table, plus
+/// The per-interface vtable type for some `best::interface`.
 template <typename Interface>
-requires requires { typename Interface::BestFuncs; }
-class vtable final {
- public:
-  /// # `best::vtable::funcs`
-  ///
-  /// Function table information specific to `Interface`.
-  using funcs = Interface::BestFuncs;
+using vtable = Interface::BestVtable;
 
-  /// # `best::vtable::vtable()`
+/// # `best::itable`
+///
+/// A complete, raw "interface table" for a `best::dyn`. This provides all of
+/// the necessary information for handling a type that implements a collection
+/// of interfaces.
+template <typename... Interfaces>
+class itable final {
+ private:
+  static constexpr bool singular = sizeof...(Interfaces) == 1;
+  using vtables = best::row<best::vtable<Interfaces>...>;
+
+ public:
+  /// # `best::itable::vtable()`
   ///
   /// Constructs a new vtable witnessing that the type `T` implements
   /// `Interface`, with the given `Interface`-specific data.
@@ -56,99 +116,105 @@ class vtable final {
   /// This constructor has no way of checking that `funcs` is actually
   /// appropriate for this vtable.
   template <typename T>
-  constexpr vtable(best::tlist<T>, funcs funcs);
+  constexpr itable(best::tlist<T>, best::vtable<Interfaces>... vtables);
 
-  /// # `best::vtable::of()`
+  /// # `best::itable::of()`
   ///
-  /// Returns the vtable for the given type, if it implements `Interface`.
+  /// Returns the itable for the given type, if it implements all of
+  /// `Interfaces`.
   template <typename T>
-  requires requires {
-    { BestImplements((T*)nullptr, (Interface*)nullptr) };
-  }
-  static constexpr const vtable& of(best::tlist<T> = {}) {
-    return BestImplements((T*)nullptr, (Interface*)nullptr);
-  }
+  static constexpr const itable& of(best::tlist<T> = {})
+    requires (best::implements<T, Interfaces> && ...);
 
-  /// # `best::vtable::layout()`
+  /// # `best::itable::layout()`
   ///
-  /// Returns the layout for the type this vtable represents.
+  /// Returns the layout for the type this itable represents.
   constexpr best::layout layout() const { return layout_; }
 
-  /// # `best::vtable::can_copy()`, `best::vtable::copy()`
+  /// # `best::itable::can_copy()`, `best::itable::copy()`
   ///
-  /// Runs the copy constructor for this vtable's type. Some types are not
+  /// Runs the copy constructor for this itable's type. Some types are not
   /// copyable; this can be queried with `can_copy()`. Calling `copy()` on a
   /// non-copyable type is undefined behavior.
   constexpr bool can_copy() const { return copy_ != nullptr; }
   constexpr void copy(void* dst, void* src) const { copy_(dst, src); }
 
-  /// # `best::vtable::destroy`
+  /// # `best::itable::destroy`
   ///
-  /// Runs the destructor for this vtable's type. `ptr` must be a pointer to
-  /// an initialized value of the type this vtable was constructed with.
+  /// Runs the destructor for this itable's type. `ptr` must be a pointer to
+  /// an initialized value of the type this itable was constructed with.
   constexpr void destroy(void* ptr) const { dtor_(ptr); }
 
-  /// # `best::vtable::operator->`
+  /// # `best::itable::operator->`
   ///
-  /// Provides access to this vtable's `funcs` value.
-  constexpr const funcs* operator->() const { return best::addr(funcs_); }
+  /// If this itable contains exactly vtable, `operator->` will yield it.
+  constexpr const auto* operator->() const requires (sizeof...(Interfaces) == 1)
+  {
+    return best::addr(vtables_[best::index<0>]);
+  }
+
+  /// # `best::itable::operator[]`
+  ///
+  /// Yields the vtable for the given type, if it is among those in this
+  /// itable.
+  template <typename I>
+  constexpr const auto& operator[](best::tlist<I>) const
+    requires (!decltype(best::lie<vtables>.select(
+      best::types<best::vtable<I>>))::types.is_empty())
+  {
+    return vtables_.as_ref().select(
+      best::types<const best::vtable<I>&>)[best::index<0>];
+  }
 
  private:
   best::layout layout_;
   void (*dtor_)(void*);
   void (*copy_)(void* dst, void* src) = nullptr;
-  funcs funcs_;
+  vtables vtables_;
 };
 
-/// # `best::interface<I>`
+/// # `best::vtable_binder`
 ///
-/// Whether `I` is an interface type usable with `best::dyn<I>`. Such a type
-/// is a class with the following interface:
-///
-/// ```
-/// class MyIface final {
-///  public:
-///   friend best::access;
-///
-///   struct BestFuncs {
-///     // ...
-///   };
-///
-///   const best::vtable<MyIface>& vtable() { return *vt_; }
-///
-///  private:
-///   constexpr my_iface(void* data, const best::vtable<MyIface>* vt)
-///     : data_(data), vt_(vt) {}
-///
-///   void* data_;
-///   const best::vtable<MyIface>* vt_;
-/// };
-/// ```
-///
-/// In other words, it must have a member type named `BestFuncs`, and it must
-/// be privately constructible from a `best::vtable`, which will contain a
-/// `BestFuncs`.
-///
-/// Although not required, it is recommended to add a static `of` function with
-/// the following signature:
-///
-/// ```
-/// template <best::as_dyn<MyIface> T>
-/// static constexpr auto of(T&& value) {
-///   return best::dyn<MyIface>::of(BEST_FWD(value));
-/// }
-/// ```
-///
-/// That way, it's easy to access interface methods generically by writing
-/// `MyIface::of(value)->foo()`.
-///
-/// The class is expected to define member functions that call function pointers
-/// stored in in `vtable().funcs`. The `BEST_INTERFACE()` macro can be used to
-/// ease implementing such boilerplate.
-template <typename I>
-concept interface = requires(void* vp, const I& iface) {
-  { iface.vtable() } -> best::same<const best::vtable<best::un_const<I>>&>;
-  requires best::dyn_internal::access::can_wrap<best::un_const<I>>();
+/// A wrapper over a function pointer with an extra `void*` argument,
+/// representing a type-erased this pointer. This is used as the type for
+/// function types in a `best::interface`'s vtable.
+template <typename Signature>
+class vtable_binder final
+  : best::traits_internal::tame<Signature>::template apply<
+      dyn_internal::binder_impl> {
+ private:
+  using impl_t = best::traits_internal::tame<Signature>::template apply<
+    dyn_internal::binder_impl>;
+
+ public:
+  /// # `vtable_binder::fnptr`
+  ///
+  /// The underlying fnptr type.
+  using fnptr = impl_t::fnptr;
+
+  /// # `vtable_binder::vtable_binder()`
+  ///
+  /// Constructs a new binder. This can be either from `nullptr`, an appropriate
+  /// function pointer with a leading `void*` argument, or a capture-less
+  /// closure whose first argument is a reference.
+  ///
+  /// In the last case, the constructor  will automatically erase the first
+  /// argument. This allows initializing a `vtable_binder<int(int)>` from
+  /// something like `[](MyClass& x, int y) { return x.field += y; }`
+  using impl_t::impl_t;
+
+  /// # `vtable_binder()`
+  ///
+  /// Calls the function. The first argument is the this pointer.
+  using impl_t::operator();
+
+  /// # `vtable_binder::operator==`
+  ///
+  /// `vtable_binder`s may be compared to `nullptr` (and no other pointer).
+  using impl_t::operator==;
+  using impl_t::operator bool;
+
+  using impl_t::operator fnptr;
 };
 
 /// # `BEST_INTERFACE()`
@@ -209,129 +275,100 @@ concept interface = requires(void* vp, const I& iface) {
 /// implementations do not need to provide this function to conform.
 struct defaulted final {};
 
-/// # `best::vtable_binder`
-///
-/// A wrapper over a function pointer with an extra `void*` argument,
-/// representing a type-erased this pointer. This is used as the type for
-/// function types in a `best::interface`'s vtable.
-template <typename Signature>
-class vtable_binder final
-  : best::traits_internal::tame<Signature>::template apply<
-      dyn_internal::binder_impl> {
- private:
-  using impl_t = best::traits_internal::tame<Signature>::template apply<
-    dyn_internal::binder_impl>;
-
- public:
-  /// # `vtable_binder::fnptr`
-  ///
-  /// The underlying fnptr type.
-  using fnptr = impl_t::fnptr;
-
-  /// # `vtable_binder::vtable_binder()`
-  ///
-  /// Constructs a new binder. This can be either from `nullptr`, an appropriate
-  /// function pointer with a leading `void*` argument, or a capture-less
-  /// closure whose first argument is a reference.
-  ///
-  /// In the last case, the constructor  will automatically erase the first
-  /// argument. This allows initializing a `vtable_binder<int(int)>` from
-  /// something like `[](MyClass& x, int y) { return x.field += y; }`
-  using impl_t::impl_t;
-
-  /// # `vtable_binder()`
-  ///
-  /// Calls the function. The first argument is the this pointer.
-  using impl_t::operator();
-
-  /// # `vtable_binder::operator==`
-  ///
-  /// `vtable_binder`s may be compared to `nullptr` (and no other pointer).
-  using impl_t::operator==;
-  using impl_t::operator bool;
-
-  using impl_t::operator fnptr;
-};
-
-/// # `best::implements<T, I>`
-///
-/// Checks whether a type implements the given interface type. To implement it,
-/// the FTADLE `BestImplements(T&, I*)` must be findable by ADL. This function
-/// must return an appropriate vtable type.
-///
-/// Both arguments actually passed to `BestImplements` will be null.
-template <typename T, typename Interface>
-concept implements = requires {
-  // Force this constraint to resolve before we name best::vtable to avoid a
-  // requirement cycle. This might be a clang bug, but concepts are so
-  // impossible to understand it might also be nominal. :)
-  typename Interface::BestFuncs;
-
-  { best::vtable<Interface>::of(best::types<T>) };
-};
-
-template <best::interface>
-class dyn;
-
-/// # `best::as_dyn<Interface>`
-///
-/// A type that can be accessed as a `best::dyn<Interface>`. This includes all
-/// types which implement it, as well as pointer types that convert to
-/// `best::dynptr<Interface>`. Use `best::dyn<Interface>::of()` to obtain a
-/// `best::dynptr`.
-template <typename T, typename Interface>
-concept as_dyn = requires(T&& value) {
-  { best::dyn<Interface>::of(value) };
-};
-
-/// # `best::dynptr<I>`
-///
-/// A pointer to a `best::dyn`. This is a convenience shorthand.
-template <best::interface I>
-using dynptr = best::ptr<best::dyn<I>>;
-
-/// # `best::dyn<Interface>`
+/// # `best::dyn<Interfaces>`
 ///
 /// A generic polymorphic type wrapper, for use with e.g. `best::box`.
 /// `best::dyn` generalizes C++ virtual functions in a way that allows users to
 /// define new interfaces for types the do not own.
-template <best::interface Interface>
+template <best::interface... Interfaces>
 class dyn final {
  public:
   // Non-constructible; only usable with e.g. best::box and best::ptr.
   constexpr dyn() = delete;
 
-  /// # `best::dyn::of()`
-  ///
-  /// Wraps a value which satisfies `Interface` in an appropriate way, producing
-  /// a `best::dynptr<Interface>` for the contained value. A type which can be
-  /// passed to `of` satisfies `best::as_dyn<Interface>`.
-  ///
-  /// This function returns the least-qualified of `best::dynptr<Interface>`
-  /// or `best::dynptr<const Interface>` possible.
-  template <typename P>
-  static constexpr auto of(P&& ptr)
-    requires (best::converts_to<P &&, dynptr<Interface>> ||
-              best::converts_to<P &&, dynptr<const Interface>> ||
-              best::converts_to<best::as_raw_ptr<P>, dynptr<Interface>> ||
-              best::converts_to<best::as_raw_ptr<P>, dynptr<const Interface>>)
-  {
-    if constexpr (best::converts_to<best::as_raw_ptr<P>, dynptr<Interface>>) {
-      return dynptr<Interface>(best::addr(ptr));
-    } else if constexpr (best::converts_to<best::as_raw_ptr<P>,
-                                           dynptr<const Interface>>) {
-      return dynptr<const Interface>(best::addr(ptr));
-    } else if constexpr (best::converts_to<P&&, dynptr<Interface>>) {
-      return dynptr<Interface>(BEST_FWD(ptr));
-    } else if constexpr (best::converts_to<P&&, dynptr<const Interface>>) {
-      return dynptr<const Interface>(BEST_FWD(ptr));
-    }
-  }
-
  private:
   class meta;
+  class accessor;
   friend best::access;
   using BestPtrMetadata = meta;
+};
+
+/// # `best::dynptr<Interfaces>`
+///
+/// A pointer to a `best::dyn`. This is a convenience shorthand.
+template <best::interface... Interfaces>
+using dynptr = best::ptr<best::dyn<Interfaces...>>;
+
+/// # `best::as_dyn()`
+///
+/// Extracts an accessor for some interface from a type that implements it,
+/// or a pointer to it. It returns a special accessor, rather than a value of
+/// the interface itself, in order to ensure const-correctness. The returned
+/// value can be used to access interface methods via `operator->`.
+///
+/// This function is extremely general: it is the primary mechanism for calling
+/// interface functions in a generic context, such as situations which wish to
+/// be polymorphic over interface storage. For example, if `T` implements `I`,
+/// this function will uniformly handle `T&`, `T*`, `best::ptr<T>`,
+/// `best::box<T>`, `best::dynptr<I, ...>`, and `best::dynbox<I, ...>`.
+///
+/// Every interface provides a static `of` function that calls `as_dyn`.
+template <best::interface Interface, typename T>
+constexpr auto as_dyn(T&& impl)
+  requires (best::implements<T &&, Interface> ||
+            best::implements<T &&, const Interface> ||
+            best::implements<decltype(*impl), Interface> ||
+            best::implements<decltype(*impl), const Interface> ||
+            requires {
+              {
+                impl[best::types<Interface>].operator->()
+              } -> best::one_of<const Interface*, Interface*>;
+            })
+{
+  if constexpr (best::implements<T&&, Interface>) {
+    return best::dynptr<Interface>(best::addr(impl)).operator->();
+  }  //
+  else if constexpr (best::implements<T&&, const Interface>) {
+    return best::dynptr<const Interface>(best::addr(impl)).operator->();
+  }
+
+  else if constexpr (best::implements<decltype(*impl), Interface>) {
+    return best::dynptr<Interface>(best::addr(*impl)).operator->();
+  }  //
+  else if constexpr (best::implements<decltype(*impl), const Interface>) {
+    return best::dynptr<const Interface>(best::addr(*impl)).operator->();
+  }
+
+  else if constexpr (requires {
+                       {
+                         impl[best::types<Interface>].operator->()
+                       } -> best::one_of<const Interface*, Interface*>;
+                     }) {
+    return impl[best::types<Interface>];
+  }
+};
+
+/// # `best::dyn_of<...>`
+///
+/// Returns whether `value` is suitable for extracting accessors for the given
+/// interfaces. This is useful as a template parameter constraint for being
+/// polymorphic over all types which implement (or contain) a particular
+/// interface.
+template <typename T, typename... Interfaces>
+concept dyn_of = (requires(T&& value) {
+  { best::as_dyn<Interfaces>(value) };
+} && ...);
+
+/// # `best::interface_base`
+///
+/// Base class for interfaces, which provides functions common to all
+/// interfaces.
+template <typename Interface>
+class interface_base /* open */ {
+ public:
+  static constexpr auto of(best::dyn_of<Interface> auto&& impl) {
+    return best::as_dyn<Interface>(impl);
+  }
 };
 }  // namespace best
 
@@ -340,61 +377,65 @@ class dyn final {
 \* ////////////////////////////////////////////////////////////////////////// */
 
 namespace best {
-template <typename I>
-requires requires { typename I::BestFuncs; }
+template <typename... I>
 template <typename T>
-constexpr vtable<I>::vtable(best::tlist<T>, funcs funcs)
+constexpr itable<I...>::itable(best::tlist<T>, best::vtable<I>... vtables)
   : layout_(best::layout::of<T>()),
     dtor_(+[](void* vp) { best::ptr<T>((T*)vp).destroy(); }),
-    funcs_(funcs) {
+    vtables_(best::dyn_internal::apply_vtable_defaults<I, T>(vtables)...) {
   if constexpr (best::ptr<T>::can_statically_copy()) {
     copy_ = +[](void* dst_, void* src_) {
       best::ptr<T> dst((T*)dst_), src((T*)src_);
       dst.copy(src);
     };
   }
-
-  if constexpr (requires {
-                  { I::template BestFuncDefaults<T>(funcs_) };
-                }) {
-    I::template BestFuncDefaults<T>(funcs_);
-  }
 }
 
-template <best::interface I>
-class dyn<I>::meta {
-  using Interface = best::un_const<I>;
+namespace dyn_internal {
+template <typename T, typename... I>
+inline constexpr itable<I...> impl{
+  best::types<T>,
+  BestImplements((T*)nullptr, (I*)nullptr)...,
+};
+}  // namespace dyn_internal
 
+template <typename... I>
+template <typename T>
+constexpr const itable<I...>& itable<I...>::of(best::tlist<T>)
+  requires (best::implements<T, I> && ...)
+{
+  return best::dyn_internal::impl<best::un_ref<T>, best::as_auto<I>...>;
+}
+
+template <best::interface... I>
+class dyn<I...>::meta {
  public:
-  using type = I;
-  using pointee = best::copy_quals<void, I>;
-  using metadata = const best::vtable<Interface>*;
-  using as_const = dyn<const Interface>;
+  using type = dyn;
+  using pointee = best::select<(best::is_const<I> && ...), const void, void>;
+  using metadata = const best::itable<best::un_const<I>...>*;
+  using as_const = dyn<const I...>;
 
   constexpr meta() = default;
   constexpr meta(metadata vt) : vt_(vt) {}
   constexpr const metadata& to_metadata() const { return vt_; }
 
-  constexpr meta(best::tlist<best::ptr<dyn>>, const metadata& vt) : vt_(vt) {}
-  constexpr meta(best::tlist<best::ptr<dyn<Interface>>>, const metadata& vt)
-    requires best::is_const<I>
+  template <typename... J>
+  constexpr meta(best::tlist<best::ptr<dyn<J...>>>, const metadata& vt)
+    requires ((best::same<I, J> || best::same<I, const J>) && ...)
     : vt_(vt) {}
 
   template <typename P>
   constexpr meta(best::tlist<P>, const typename P::metadata&)
-    requires (P::is_thin() && best::implements<typename P::pointee, Interface>)
-    : vt_(&BestImplements((typename P::pointee*)nullptr, (Interface*)nullptr)) {
-  }
+    requires (P::is_thin() && (best::implements<typename P::pointee, I> && ...))
+    : vt_(&best::itable<I...>::of(best::types<typename P::pointee>)) {}
 
   constexpr best::layout layout() const { return vt_->layout(); }
-  constexpr auto deref(pointee* ptr) const {
-    return best::arrow<I>(
-      best::dyn_internal::access::wrap<Interface>(ptr, vt_));
-  }
+  constexpr auto deref(pointee* ptr) const { return accessor(ptr, vt_); }
 
-  template <best::implements<I> T>
-  static constexpr meta meta_for(T&&) {
-    return &best::vtable<I>::of(best::types<T>);
+  template <typename T>
+  static constexpr meta meta_for(T&&) requires (best::implements<T, I> && ...)
+  {
+    return &best::itable<I...>::of(best::types<T>);
   }
   template <typename T>
   static constexpr void construct(pointee* dst, bool assign, T&& arg) {
@@ -413,6 +454,40 @@ class dyn<I>::meta {
 
  private:
   metadata vt_ = nullptr;
+};
+
+template <best::interface... I>
+class dyn<I...>::accessor {
+ private:
+  template <typename J>
+  static constexpr auto find =
+    best::types<best::un_const<I>...>.template find<best::un_const<J>>();
+  template <typename J>
+  static constexpr bool is_const =
+    best::is_const<typename best::tlist<I...>::template type<*find<J>>>;
+
+ public:
+  constexpr auto operator->() const requires (sizeof...(I) == 1)
+  {
+    return (*this)[best::types<I...>];
+  }
+
+  template <typename J>
+  constexpr auto operator[](best::tlist<J>) const requires (find<J>.has_value())
+  {
+    return best::arrow<best::select<is_const<J>, const J, J>>(
+      best::dyn_internal::access::wrap<J>(
+        data_, best::addr((*vt_)[best::types<best::un_const<J>>])));
+  }
+
+ private:
+  friend dyn::meta;
+  constexpr explicit accessor(typename meta::pointee* data,
+                              typename meta::metadata vt)
+    : data_(data), vt_(vt) {}
+
+  typename meta::pointee* data_;
+  typename meta::metadata vt_;
 };
 }  // namespace best
 

--- a/best/memory/BUILD
+++ b/best/memory/BUILD
@@ -11,6 +11,7 @@ cc_library(
     "//best/base:hint",
     "//best/base:niche",
     "//best/base:ord",
+    "//best/func:arrow",
     "//best/meta:init",
     "//best/meta:tlist",
     "//best/meta/traits:types",

--- a/best/memory/ptr.h
+++ b/best/memory/ptr.h
@@ -28,6 +28,7 @@
 #include "best/base/ord.h"
 #include "best/base/port.h"
 #include "best/base/tags.h"
+#include "best/func/arrow.h"
 #include "best/log/internal/crash.h"
 #include "best/memory/internal/ptr.h"
 #include "best/memory/layout.h"
@@ -401,7 +402,7 @@ class ptr final {
   constexpr auto get() const;
   constexpr view operator*() const { return deref(); }
   constexpr auto operator->() const {
-    if constexpr (best::is_raw_ptr<decltype(get())>) {
+    if constexpr (best::can_arrow<decltype(get())>) {
       return get();
     } else {
       return best::arrow(get());

--- a/best/meta/traits/types.h
+++ b/best/meta/traits/types.h
@@ -72,6 +72,12 @@ using dependent_value =
 template <typename... Pack>
 concept same = traits_internal::same<Pack...>::value;
 
+/// # `best::one_of<T, Alts...>
+///
+/// Returns whether `T` is among the types in `Alts`.
+template <typename T, typename... Alts>
+concept one_of = (best::same<T, Alts> || ...);
+
 /// # `best::lie<T>`
 ///
 /// Lies to the compiler that we can materialize a `T`. This is just a shorter


### PR DESCRIPTION
This change makes `best::dyn` a variadic template, so that you can have e.g. `best::dynptr<reader, writer>`, much like Rust has `&dyn Read + Write`. To enable this, the interface for implementing interfaces has changed.

- `best::itable` is the new name for `best::vtable`, which in turn is now an alias for extracting a `BestVtable` from an interface type, which is the new name for `BestFuncs`.
- `BestImplements` now needs to return a `best::vtable<I>` by value, and machinery inside of `best::itable` will automatically create a global variable for the result; `best::itable::of` now does more than just call `BestImplements`. This makes `BestImplements` very painless to implement by hand.
- `best::itable<I, J, ...>` no longer has an `operator->`, since there is more than one vtable; `operator[]` can be used to get the vtable for a particular interface.
- `best::dynptr<I, J, ...>` provides access to the call interfaces for `I` and `J` via `operator[]` too.
- `best::dyn::of` is now `best::as_dyn` (which itself was renamed to `best::dyn_of`). This is so that it can be called with const interface values.
- All interfaces must derive `best::interface_base`, which allows us to force all interfaces to provide an `of()` static function, instead of having ti be convention.

Also fixed `best::row::as_ref()` being completely broken. Oops.