### PR TITLE
Add `best::defer`

### DIFF
--- a/best/func/BUILD
+++ b/best/func/BUILD
@@ -92,3 +92,21 @@ cc_test(
     "//best/test",
   ],
 )
+
+cc_library(
+  name = "defer",
+  hdrs = ["defer.h"],
+  deps = [
+    ":call",
+  ],
+)
+
+cc_test(
+  name = "defer_test",
+  srcs = ["defer_test.cc"],
+  linkopts = ["-rdynamic"],
+  deps = [
+    ":defer",
+    "//best/test",
+  ],
+)

--- a/best/func/defer.h
+++ b/best/func/defer.h
@@ -71,7 +71,7 @@ class [[nodiscard(
 
  private:
   Cb cb_;
-  bool cancelled_;
+  bool cancelled_ = false;
 };
 
 template <typename Cb>

--- a/best/func/defer.h
+++ b/best/func/defer.h
@@ -1,0 +1,83 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_FUNC_DEFER_H_
+#define BEST_FUNC_DEFER_H_
+
+#include "best/base/tags.h"
+#include "best/func/call.h"
+
+//! Deferred execution.
+//!
+//! `best::defer` is a mechanism for deferring execution of some closure until
+//! scope exit.
+
+namespace best {
+/// # `best::defer`
+///
+/// Defers execution of a closure until scope exit.
+///
+/// ```
+/// best::defer d_ = []{ ... };
+/// ```
+template <typename Guard, typename Cb>
+class [[nodiscard(
+  "a best::defer must be assigned to variable to have any effect")]] defer
+  final {
+ public:
+  BEST_CTAD_GUARD_("best::defer", Guard);
+
+  /// # `defer::defer()`
+  ///
+  /// Constructs a new tap by wrapping a callback.
+  constexpr defer(Cb&& cb) : cb_(BEST_FWD(cb)) {}
+  constexpr defer(best::bind_t, Cb&& cb) : cb_(BEST_FWD(cb)) {}
+
+  /// # `defer::defer()`
+  ///
+  /// Runs the defer at scope exit.
+  constexpr ~defer() { run(); }
+
+  /// # `defer::cancel()`
+  ///
+  /// Inhibits execution of the defer.
+  constexpr void cancel() { cancelled_ = true; }
+
+  /// # `defer::run()`
+  ///
+  /// Forcibly runs the defer. Further calls to run() will have no effect.
+  constexpr void run() {
+    if (!cancelled_) {
+      best::call(cb_);
+      cancel();
+    }
+  }
+
+ private:
+  Cb cb_;
+  bool cancelled_;
+};
+
+template <typename Cb>
+defer(Cb&&) -> defer<tags_internal_do_not_use::ctad_guard, best::as_auto<Cb>>;
+template <typename Cb>
+defer(best::bind_t, Cb&&) -> defer<tags_internal_do_not_use::ctad_guard, Cb&&>;
+}  // namespace best
+
+#endif  // BEST_FUNC_DEFER_H_

--- a/best/func/defer_test.cc
+++ b/best/func/defer_test.cc
@@ -1,0 +1,48 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#include "best/func/defer.h"
+
+#include "best/test/test.h"
+
+namespace best::tap_test {
+best::test Defer = [](auto& t) {
+  int x = 0;
+
+  {
+    best::defer d_ = [&] { x = 42; };
+  }
+  t.expect_eq(x, 42);
+
+  {
+    best::defer d_ = [&] { x = 0; };
+    d_.cancel();
+  }
+  t.expect_eq(x, 42);
+
+  {
+    best::defer d_ = [&] { x *= 2; };
+    d_.run();
+    t.expect_eq(x, 84);
+    d_.run();
+    t.expect_eq(x, 84);
+  }
+  t.expect_eq(x, 84);
+};
+}  // namespace best::tap_test


### PR DESCRIPTION
This is our version of `absl::Cleanup`, and is basically identical to it. It makes it easy to run arbitrary code on scope exit.