### PR TITLE
Add double-ended iterators

### DIFF
--- a/best/container/vec.h
+++ b/best/container/vec.h
@@ -546,6 +546,13 @@ vec(Iter) -> vec<best::as_auto<typename best::iter_type<Iter>>>;
 \* ////////////////////////////////////////////////////////////////////////// */
 
 namespace best {
+namespace iter_internal {
+template <typename T>
+struct vec {
+  using type = best::vec<T>;
+};
+}  // namespace iter_internal
+
 template <best::relocatable T, size_t max_inline, best::allocator A>
 vec<T, max_inline, A>::vec(const vec& that)
   requires best::copyable<T> && best::copyable<alloc>

--- a/best/iter/bounds.h
+++ b/best/iter/bounds.h
@@ -238,6 +238,20 @@ struct int_range final {
       return ret;
     }
 
+    constexpr opt_t next_back() {
+      if (count_ == 0) {
+        if (plus_one_) {
+          plus_one_ = false;
+          return start_;
+        }
+        return {};
+      }
+
+      auto ret = start_ + count_ - !plus_one_;
+      count_ = (best::overflow(count_) - 1).wrap();
+      return ret;
+    }
+
     constexpr std::array<size_t, 2> size_hint() const {
       // TODO(mcyoung): This will overflow for uint64 ranges, need to return
       // something else.

--- a/best/iter/bounds_test.cc
+++ b/best/iter/bounds_test.cc
@@ -87,12 +87,14 @@ best::test Debug = [](auto& t) {
 
 best::test Iter = [](auto& t) {
   best::bounds b = {.start = 5, .end = 11};
-  t.expect_eq(best::vec(b.iter()), {5, 6, 7, 8, 9, 10});
+  t.expect_eq(b.iter().to_vec(), {5, 6, 7, 8, 9, 10});
+  t.expect_eq(b.iter().rev().to_vec(), {10, 9, 8, 7, 6, 5});
   t.expect_eq(b.iter().count(), 6);
   t.expect_eq(b.iter().last(), 10);
 
   b = {.start = 5, .including_end = 11};
-  t.expect_eq(best::vec(b.iter()), {5, 6, 7, 8, 9, 10, 11});
+  t.expect_eq(b.iter().to_vec(), {5, 6, 7, 8, 9, 10, 11});
+  t.expect_eq(b.iter().rev().to_vec(), {11, 10, 9, 8, 7, 6, 5});
   t.expect_eq(b.iter().count(), 7);
   t.expect_eq(b.iter().last(), 11);
 
@@ -100,14 +102,17 @@ best::test Iter = [](auto& t) {
     .start = best::max_of<size_t> - 1,
     .including_end = best::max_of<size_t>,
   };
-  t.expect_eq(best::vec(b.iter()),
+  t.expect_eq(b.iter().to_vec(),
               {best::max_of<size_t> - 1, best::max_of<size_t>});
+  t.expect_eq(b.iter().rev().to_vec(),
+              {best::max_of<size_t>, best::max_of<size_t> - 1});
   t.expect_eq(b.iter().count(), 2);
   t.expect_eq(b.iter().last(), best::max_of<size_t>);
 
   best::int_range i = {.start = uint8_t(0)};
-  t.expect_eq(best::vec(i.iter()),
-              best::vec(best::bounds{.count = 256}.iter()));
+  t.expect_eq(i.iter().to_vec(), best::bounds{.count = 256}.iter().to_vec());
+  t.expect_eq(i.iter().rev().to_vec(),
+              best::bounds{.count = 256}.iter().rev().to_vec());
   t.expect_eq(i.iter().count(), 256);
   t.expect_eq(i.iter().last(), 255);
 };

--- a/best/memory/span.h
+++ b/best/memory/span.h
@@ -927,7 +927,8 @@ constexpr span<T, n> span<T, n>::from_nul(T* data) {
   }
 
   auto ptr = data;
-  while (*ptr++ != T{0});
+  while (*ptr++ != T{0})
+    ;
   return best::span(data, ptr - data - 1);
 }
 
@@ -1206,7 +1207,6 @@ constexpr best::option<best::row<span<T>, span<T>>> span<T, n>::split_once(
     best::span(data() + *idx + 1, size() - *idx - 1),
   }};
 }
-
 
 template <best::is_object T, best::option<best::dependent<size_t, T>> n>
 template <best::equatable<T> U>

--- a/best/memory/span_test.cc
+++ b/best/memory/span_test.cc
@@ -278,7 +278,7 @@ best::test Find = [](auto& t) {
     bytes.split('4').rev().to_vec(),
     {{'5', '6', '7', '8', '9', '\0'}, {}, {}, {}, {}, {'1', '2', '3'}});
 
-  int a[] = {1, 2, 3, 4, 4, 4, 4, 4, 5, 6, 7, 8, 9, 0};
+  const int a[] = {1, 2, 3, 4, 4, 4, 4, 4, 5, 6, 7, 8, 9, 0};
   best::span ints = a;
 
   t.expect_eq(ints.find(1), 0);
@@ -303,7 +303,7 @@ best::test Find = [](auto& t) {
   t.expect_eq(ints.split(4).rev().to_vec(),
               {{5, 6, 7, 8, 9, 0}, {}, {}, {}, {}, {1, 2, 3}});
 
-  SlowCmp b[] = {1, 2, 3, 4, 4, 4, 4, 4, 5, 6, 7, 8, 9, 0};
+  const SlowCmp b[] = {1, 2, 3, 4, 4, 4, 4, 4, 5, 6, 7, 8, 9, 0};
   best::span slow = b;
 
   t.expect_eq(slow.find(1), 0);

--- a/best/memory/span_test.cc
+++ b/best/memory/span_test.cc
@@ -263,10 +263,20 @@ best::test Find = [](auto& t) {
   t.expect_eq(bytes.find(best::span<char>{}), 0);
   t.expect_eq(bytes.find({'3', '4', '4'}), 2);
 
-  best::vec<best::span<const char>> byte_split(bytes.split('4'));
+  t.expect_eq(bytes.rfind('1'), 0);
+  t.expect_eq(bytes.rfind('4'), 7);
+  t.expect_eq(bytes.rfind('9'), 12);
+  t.expect_eq(bytes.rfind('\0'), 13);
+  t.expect_eq(bytes.rfind('a'), best::none);
+  t.expect_eq(bytes.rfind(best::span<char>{}), 0);
+  t.expect_eq(bytes.rfind({'3', '4', '4'}), 2);
+
   t.expect_eq(
-    byte_split,
+    bytes.split('4').to_vec(),
     {{'1', '2', '3'}, {}, {}, {}, {}, {'5', '6', '7', '8', '9', '\0'}});
+  t.expect_eq(
+    bytes.split('4').rev().to_vec(),
+    {{'5', '6', '7', '8', '9', '\0'}, {}, {}, {}, {}, {'1', '2', '3'}});
 
   int a[] = {1, 2, 3, 4, 4, 4, 4, 4, 5, 6, 7, 8, 9, 0};
   best::span ints = a;
@@ -280,8 +290,18 @@ best::test Find = [](auto& t) {
   t.expect_eq(ints.find(best::span<int>{}), 0);
   t.expect_eq(ints.find({3, 4, 4}), 2);
 
-  best::vec<best::span<const int>> int_split(ints.split(4));
-  t.expect_eq(int_split, {{1, 2, 3}, {}, {}, {}, {}, {5, 6, 7, 8, 9, 0}});
+  t.expect_eq(ints.rfind(1), 0);
+  t.expect_eq(ints.rfind(4), 7);
+  t.expect_eq(ints.rfind(9), 12);
+  t.expect_eq(ints.rfind(0), 13);
+  t.expect_eq(ints.rfind(50), best::none);
+  t.expect_eq(ints.rfind(best::span<int>{}), 0);
+  t.expect_eq(ints.rfind({3, 4, 4}), 2);
+
+  t.expect_eq(ints.split(4).to_vec(),
+              {{1, 2, 3}, {}, {}, {}, {}, {5, 6, 7, 8, 9, 0}});
+  t.expect_eq(ints.split(4).rev().to_vec(),
+              {{5, 6, 7, 8, 9, 0}, {}, {}, {}, {}, {1, 2, 3}});
 
   SlowCmp b[] = {1, 2, 3, 4, 4, 4, 4, 4, 5, 6, 7, 8, 9, 0};
   best::span slow = b;
@@ -295,8 +315,8 @@ best::test Find = [](auto& t) {
   t.expect_eq(slow.find(best::span<int>{}), 0);
   t.expect_eq(slow.find({3, 4, 4}), 2);
 
-  best::vec<best::span<const SlowCmp>> slow_split(slow.split(4));
-  t.expect_eq(slow_split, {{1, 2, 3}, {}, {}, {}, {}, {5, 6, 7, 8, 9, 0}});
+  t.expect_eq(slow.split(4).to_vec(),
+              {{1, 2, 3}, {}, {}, {}, {}, {5, 6, 7, 8, 9, 0}});
 };
 
 best::test Affixes = [](auto& t) {

--- a/best/text/encoding.h
+++ b/best/text/encoding.h
@@ -23,7 +23,6 @@
 #include <cstddef>
 
 #include "best/base/tags.h"
-#include "best/container/option.h"
 #include "best/container/result.h"
 #include "best/memory/span.h"
 #include "best/meta/init.h"

--- a/best/text/internal/utf.h
+++ b/best/text/internal/utf.h
@@ -113,17 +113,17 @@ constexpr int32_t decode8(const char* data, size_t rune_bytes) {
 }
 
 constexpr int32_t undecode8(best::span<const char>* input) {
-  size_t len = 0;
-  for (; len < 4; ++len) {
+  size_t len = 1;
+  for (; len < 5; ++len) {
     if (input->size() < len) { return OutOfBounds; }
     auto byte =
-      input->at(unsafe("bounds check above"), input->size() - len - 1);
+      input->at(unsafe("bounds check above"), input->size() - len);
     if (best::leading_ones(byte) != 1) { break; }
   }
-  if (len == 4) { return Invalid; }
+  if (len == 5) { return Invalid; }
   *input = {input->data(), input->size() - len};
 
-  return decode8(input->data().offset(input->size() - len).raw(), len);
+  return decode8(input->data().offset(input->size()).raw(), len);
 }
 
 // This function expects the caller to pre-compute encode8_size.

--- a/best/text/internal/utf.h
+++ b/best/text/internal/utf.h
@@ -116,8 +116,7 @@ constexpr int32_t undecode8(best::span<const char>* input) {
   size_t len = 1;
   for (; len < 5; ++len) {
     if (input->size() < len) { return OutOfBounds; }
-    auto byte =
-      input->at(unsafe("bounds check above"), input->size() - len);
+    auto byte = input->at(unsafe("bounds check above"), input->size() - len);
     if (best::leading_ones(byte) != 1) { break; }
   }
   if (len == 5) { return Invalid; }


### PR DESCRIPTION
Iterator implementations that provide `next_back()` will now be double-ended, which means that they can be reversed with `iter::rev()`.

In addition, all iterators that can be double-ended have been made double ended, and `best::text` now has several functions for iterating/searching from the back of the string, but only for self-syncing encodings. I also found bugs in untested code (yippee).