### PR TITLE
Add `best::table`, a hash table implementation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,3 @@
 # Makes bazel test always print errors.
 test --test_output=errors
+build --copt=-ftemplate-backtrace-limit=0

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  Add: ['-march=native']

--- a/best/base/BUILD
+++ b/best/base/BUILD
@@ -26,6 +26,11 @@ cc_library(
 )
 
 cc_library(
+  name = "arch",
+  hdrs = ["arch.h"],
+)
+
+cc_library(
   name = "macro",
   hdrs = [
     "internal/macro.h",

--- a/best/base/arch.h
+++ b/best/base/arch.h
@@ -1,0 +1,109 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_BASE_INTRINSICS_H_
+#define BEST_BASE_INTRINSICS_H_
+
+//! Helpers for working with vendor intrinsics. This file will include all
+//! the relevant intrinsics headers *and* will define macros for detecting what
+//! features are statically available.
+//!
+//! Every macro is always defined; they should be used with `#if`, not `#ifdef`.
+
+/// # `BEST_X86`
+///
+/// True if we're targeting `x86_64`.
+#ifdef __x86_64__
+#define BEST_X86 1
+#else
+#define BEST_X86 0
+#endif
+
+/// # `BEST_AARCH64`
+///
+/// True if we're targeting `aarch64`.
+#ifdef __aarch64__
+#define BEST_AARCH64 1
+#else
+#define BEST_AARCH64 0
+#endif
+
+#if !(BEST_X86 || BEST_AARCH64)
+#error "unsupported architecture :("
+#endif
+
+/// # `BEST_SSE`, `BEST_SSE2`, `BEST_SSE3`, `BEST_SSSE3`
+/// # `BEST_SSE41`, `BEST_SSE42`, `BEST_SSE4A`
+///
+/// True if the named x86 extension is statically available.
+#ifdef __SSE__
+#define BEST_SSE 1
+#else
+#define BEST_SSE 0
+#endif
+#ifdef __SSE2__
+#define BEST_SSE2 1
+#else
+#define BEST_SSE2 0
+#endif
+#ifdef __SSE3__
+#define BEST_SSE3 1
+#else
+#define BEST_SSE3 0
+#endif
+#ifdef __SSSE3__
+#define BEST_SSSE3 1
+#else
+#define BEST_SSSE3 0
+#endif
+#ifdef __SSE4_1__
+#define BEST_SSE41 1
+#else
+#define BEST_SSE41 0
+#endif
+#ifdef __SSE4_2__
+#define BEST_SSE42 1
+#else
+#define BEST_SSE42 0
+#endif
+#ifdef __SSE4A__
+#define BEST_SSE4A 1
+#else
+#define BEST_SSE4A 0
+#endif
+
+/// # `BEST_AVX`, `BEST_AVX2`
+///
+/// True if the named x86 extension is statically available.
+#ifdef __AVX__
+#define BEST_AVX 1
+#else
+#define BEST_AVX 0
+#endif
+#ifdef __AVX2__
+#define BEST_AVX2 1
+#else
+#define BEST_AVX2 0
+#endif
+
+#if BEST_X86
+#include <x86intrin.h>
+#endif // BEST_X86
+
+#endif  // BEST_BASE_INTRINSICS_H_

--- a/best/base/fwd.h
+++ b/best/base/fwd.h
@@ -190,6 +190,10 @@ struct access;
 namespace dyn_internal {
 struct access;
 }
+namespace format_internal {
+template <typename, typename...>
+class templ;
+}
 }  // namespace best
 
 #endif  // BEST_BASE_FWD_H_

--- a/best/base/hint.h
+++ b/best/base/hint.h
@@ -106,6 +106,33 @@ BEST_INLINE_ALWAYS constexpr void assume(bool truth) {
   if (!std::is_constant_evaluated()) { asm volatile("" ::"m,r"(value)); }
   return decltype(value)(value);
 }
+
+/// # `best::prefetch_locality`
+///
+/// A locality value for a prefetch operation. Specifies which cache the
+/// prefetched memory should stick around in.
+enum class prefetch_locality {
+  Nontemporal = 0,
+  L3 = 1,
+  L2 = 2,
+  L1 = 3,
+};
+
+/// # `best::prefetch_for_read()`, `best::prefetch_for_write()`
+///
+/// Prefetches the given memory.
+template <best::prefetch_locality locality = best::prefetch_locality::L1>
+BEST_INLINE_SYNTHETIC constexpr void prefetch_for_read(const void* addr) {
+  if (!std::is_constant_evaluated()) {
+    __builtin_prefetch(addr, 0, int(locality));
+  }
+}
+template <best::prefetch_locality locality = best::prefetch_locality::L1>
+BEST_INLINE_SYNTHETIC constexpr void prefetch_for_write(const void* addr) {
+  if (!std::is_constant_evaluated()) {
+    __builtin_prefetch(addr, 1, int(locality));
+  }
+}
 }  // namespace best
 
 #endif  // BEST_BASE_HINT_H_

--- a/best/container/BUILD
+++ b/best/container/BUILD
@@ -10,6 +10,7 @@ cc_library(
     ":pun",
     "//best/base:port",
     "//best/base:tags",
+    "//best/hash",
     "//best/log/internal:crash",
   ],
 )
@@ -31,6 +32,7 @@ cc_library(
   deps = [
     "//best/base:ord",
     "//best/memory:ptr",
+    "//best/hash",
   ]
 )
 
@@ -49,6 +51,7 @@ cc_library(
   hdrs = ["option.h"],
   deps = [
     ":choice",
+    "//best/hash",
     "//best/log/internal:crash",
   ],
 )
@@ -97,6 +100,7 @@ cc_library(
   deps = [
     ":choice",
     ":row",
+    "//best/hash",
     "//best/log/internal:crash",
   ],
 )
@@ -122,6 +126,7 @@ cc_library(
   ],
   deps = [
     ":object",
+    "//best/hash",
     "//best/base:port",
     "//best/base:tags",
   ],
@@ -143,6 +148,7 @@ cc_library(
   hdrs = ["box.h"],
   deps = [
     "//best/func:dyn",
+    "//best/hash",
     "//best/memory:allocator",
     "//best/memory:ptr",
   ]
@@ -183,6 +189,36 @@ cc_test(
   linkopts = ["-rdynamic"],
   deps = [
     ":vec",
+    "//best/test",
+    "//best/test:fodder",
+  ],
+)
+hash
+cc_library(
+  name = "table",
+  hdrs = [
+    "table.h",
+    "internal/table.h",
+  ],
+  deps = [
+    ":option",
+    "//best/base:arch",
+    "//best/hash",
+    "//best/hash:fxhash",
+    "//best/hash:impls",
+    "//best/memory:allocator",
+    "//best/memory:span",
+    "//best/memory:layout",
+    "//best/meta/traits:pairs",
+  ],
+)
+
+cc_test(
+  name = "table_test",
+  srcs = ["table_test.cc"],
+  linkopts = ["-rdynamic"],
+  deps = [
+    ":table",
     "//best/test",
     "//best/test:fodder",
   ],

--- a/best/container/box.h
+++ b/best/container/box.h
@@ -26,6 +26,7 @@
 #include "best/container/object.h"
 #include "best/container/option.h"
 #include "best/func/dyn.h"
+#include "best/hash/hash.h"
 #include "best/memory/allocator.h"
 #include "best/memory/layout.h"
 #include "best/memory/ptr.h"
@@ -258,6 +259,13 @@ class BEST_RELOCATABLE box final {
       auto that = best::as_auto<decltype(query)>::template of<T>.uses_method;
       return that && that(r);
     };
+  }
+
+  template <best::hash_state State>
+  constexpr friend void BestHash(best::hasher<State>& h, const box& value)
+    requires requires { h.write(*value); }
+  {
+    h.write(*value);
   }
 
   template <typename U>

--- a/best/container/choice.h
+++ b/best/container/choice.h
@@ -25,9 +25,11 @@
 #include "best/base/ord.h"
 #include "best/base/tags.h"
 #include "best/container/internal/choice.h"
+#include "best/hash/hash.h"
 #include "best/log/internal/crash.h"
 #include "best/log/location.h"
 #include "best/meta/init.h"
+#include "best/meta/traits/empty.h"
 
 //! A sum type, like `std::variant`.
 //!
@@ -327,6 +329,14 @@ class choice final {
     query.uses_method = [](auto r) {
       return (Q::template of<Alts>.uses_method(r) && ...);
     };
+  }
+
+  template <best::hash_state State>
+  constexpr friend void BestHash(best::hasher<State>& h, const choice& value)
+    requires (best::hashable<Alts> && ...)
+  {
+    value.index_match(
+      [&](auto idx, const auto& value) { h.write(idx.value, value); });
   }
 
   // Comparisons.

--- a/best/container/internal/table.h
+++ b/best/container/internal/table.h
@@ -1,0 +1,493 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_CONTAINER_INTERNAL_TABLE_H_
+#define BEST_CONTAINER_INTERNAL_TABLE_H_
+
+#include <emmintrin.h>
+#include <stdint.h>
+
+#include <cstring>
+
+#include "best/base/arch.h"
+#include "best/base/hint.h"
+#include "best/container/option.h"
+#include "best/hash/fxhash.h"
+#include "best/hash/impls.h"
+#include "best/log/wtf.h"
+#include "best/math/bit.h"
+#include "best/math/int.h"
+#include "best/memory/layout.h"
+#include "best/meta/traits/empty.h"
+
+namespace best::table_internal {
+template <typename table>
+class iter_impl;
+
+struct ctrl final {
+  static const ctrl Empty, Tombstone, Sentinel;
+
+  constexpr ctrl() = default;
+  constexpr ctrl(int8_t bits) : bits(bits) {}
+
+  constexpr bool is_occupied() const { return bits >= 0; }
+  constexpr bool is_vacant() const { return bits < -1; }
+  constexpr bool is_empty() const { return bits == Empty; }
+  constexpr bool is_tombstone() const { return bits == Tombstone; }
+
+  constexpr bool operator==(const ctrl&) const = default;
+
+  friend void BestFmt(auto& fmt, ctrl c) {
+    if (c.is_empty()) {
+      fmt.write("--");
+    } else if (c.is_tombstone()) {
+      fmt.write("🪦");
+    } else {
+      fmt.format("{:02x}", best::to_unsigned(c.bits));
+    }
+  }
+
+  int8_t bits;
+};
+
+inline constexpr ctrl ctrl::Empty = 0b1000'0000;
+inline constexpr ctrl ctrl::Tombstone = 0b1111'1110;
+inline constexpr ctrl ctrl::Sentinel = 0b1111'1111;
+
+inline uint64_t seed(const void* array) { return (uintptr_t)array >> 12; }
+
+// A processed hash from a table.
+struct hash final {
+  template <typename K, typename H>
+  static hash compute(const auto& query, const auto& id, const void* salt) {
+    best::hasher<H> hasher;
+    id.template hash<K>(hasher, query);
+    uint64_t h = hasher.finish();
+
+    return {
+      .h1 = (h >> 7) ^ (reinterpret_cast<uintptr_t>(salt) >> 12),
+      .h2 = h & 0x7f,
+    };
+  }
+
+  uint64_t h1;
+  ctrl h2;
+};
+
+template <typename I = best::default_identity, typename H = best::fxhash,
+          typename A = best::malloc>
+struct policy final {
+  using identity = I;
+  using hash_state = H;
+  using allocator = A;
+};
+
+/// A general bitset, stored in an integer.
+///
+/// `width` is the number of bits in the integer dedicated to each. The nth bit
+/// is set when the nth run of `width` bits is not all zeros. `len` is the total
+/// length of the bitset.
+///
+/// For example, when `width` is 1, this is an actual bitset. When `width` is
+/// 8, each byte corresponds to one bit.
+template <typename Int, size_t len, size_t width>
+struct bitset final {
+  static_assert(width * len <= best::bits_of<Int>);
+  Int bits;
+
+  bool empty() const { return bits == 0; }
+
+  /// Lowest and highest set bit index in the set.
+  uint32_t lowest() const { return best::trailing_zeros(bits) / width; }
+  uint32_t highest() const { return best::bits_for(bits) / width; }
+
+  /// The number of leading and trailing zero bits.
+  uint32_t trailing_zeros() const { return lowest(); }
+  uint32_t leading_zeros() const {
+    auto total_bits = width * len;
+    auto extra_bits = best::bits_of<Int> - total_bits;
+    return best::leading_zeros(bits) / width - extra_bits;
+  }
+
+  /// Returns the next bit index set.
+  BEST_INLINE_ALWAYS
+  best::option<uint32_t> next() {
+    if (empty()) { return best::none; }
+
+    uint32_t idx = lowest();
+    bits &= bits - 1;
+    return idx;
+  }
+};
+
+#if BEST_SSE2
+// An implementation of the group operations using an SSE2 (xmm) vector.
+class group_sse2 final {
+ public:
+  using mask = bitset<uint64_t, 16, 1>;
+
+  group_sse2() = default;
+  group_sse2(__m128i xmm) : xmm_(xmm){};
+
+  static group_sse2 load(const void* array, size_t offset) {
+    auto* ptr = (const char*)array + offset;
+
+    return _mm_loadu_si128((const __m128i*)ptr);
+  }
+
+  void store(void* array, size_t offset) {
+    auto* ptr = (char*)array + offset;
+    _mm_storeu_si128((__m128i*)ptr, xmm_);
+  }
+
+  mask match(ctrl h2) const {
+    auto broadcast = _mm_set1_epi8(h2.bits);
+    auto eq = _mm_cmpeq_epi8(broadcast, xmm_);
+    return {.bits = uint64_t(_mm_movemask_epi8(eq))};
+  }
+
+  mask match_empty() const {
+#if BEST_SSSE3
+    // This only works because Empty is 0b1000'0000, the only value whose
+    // two's complement is itself. All other values produce non-negative bytes
+    // when pushed through `vpsignb`.
+    auto sign_bits = _mm_sign_epi8(xmm_, xmm_);
+    return {.bits = uint64_t(_mm_movemask_epi8(sign_bits))};
+#else
+    return match(ctrl::Empty);
+#endif
+  }
+
+  mask match_vacant() const {
+    auto broadcast = _mm_set1_epi8(ctrl::Sentinel.bits);
+    auto gt = _mm_cmpgt_epi8(broadcast, xmm_);
+    return {.bits = uint64_t(_mm_movemask_epi8(gt))};
+  }
+
+  uint32_t count_leading_vacant() const {
+    auto broadcast = _mm_set1_epi8(ctrl::Sentinel.bits);
+    auto gt = _mm_cmpgt_epi8(broadcast, xmm_);
+    return best::trailing_zeros(_mm_movemask_epi8(gt) + 1);
+  }
+
+  group_sse2 prepare_for_rehash() const {
+    auto msbs = _mm_set1_epi8(0b1000'0000);
+    auto x126 = _mm_set1_epi8(0b0111'1110);
+#if BEST_SSSE3
+    return _mm_or_si128(_mm_shuffle_epi8(x126, xmm_), msbs);
+#else
+    auto zero = _mm_setzero_si128();
+    auto special_mask = _mm_cmpgt_epi8(zero, xmm_);
+    return _mm_or_si128(msbs, _mm_andnot_si128(special_mask, x126));
+#endif
+  }
+
+  friend void BestFmt(auto& fmt, group_sse2 g) {
+    ctrl bytes[sizeof(group_sse2)];
+    best::span(bytes).copy_from(best::span(&g, 1).as_bytes());
+
+    bool first = true;
+    for (auto byte : bytes) {
+      if (!std::exchange(first, false)) { fmt.write(" "); }
+      fmt.format("{:?}", byte);
+    }
+  }
+
+ private:
+  __m128i xmm_;
+};
+#endif
+
+// An implementation of the group operations using plain uint64 operations.
+class group_scalar final {
+ public:
+  using mask = bitset<uint64_t, 8, 8>;
+
+  group_scalar() = default;
+  group_scalar(uint64_t reg) : reg_(reg){};
+
+  static group_scalar load(const void* array, size_t offset) {
+    auto* ptr = (const char*)array + offset;
+    group_scalar g;
+    std::memcpy(&g, ptr, sizeof(g));
+    return g;
+  }
+
+  void store(void* array, size_t offset) {
+    auto* ptr = (char*)array + offset;
+    std::memcpy(ptr, this, sizeof(*this));
+  }
+
+  mask match(ctrl h2) const {
+    // For the technique, see:
+    // http://graphics.stanford.edu/~seander/bithacks.html##ValueInWord
+    // (Determine if a word has a byte equal to n).
+    //
+    // Caveat: there are false positives but:
+    // - they only occur if there is a real match
+    // - they never occur on ctrl_t::kEmpty, ctrl_t::kDeleted, ctrl_t::kSentinel
+    // - they will be handled gracefully by subsequent checks in code
+    //
+    // Example:
+    //   v = 0x1716151413121110
+    //   hash = 0x12
+    //   retval = (v - lsbs) & ~v & msbs = 0x0000000080800000
+
+    auto x = reg_ ^ (Lsbs * h2.bits);
+    return {.bits = (x - Lsbs) & ~x & Msbs};
+  }
+
+  mask match_empty() const { return {.bits = (reg_ & (~reg_ << 6)) & Msbs}; }
+
+  mask match_vacant() const { return {.bits = (reg_ & (~reg_ << 7)) & Msbs}; }
+
+  uint32_t count_leading_vacant() const {
+    return best::trailing_zeros((((~reg_ & (reg_ >> 7)) | Gaps) + 1) + 7) / 8;
+  }
+
+  group_scalar prepare_for_rehash() const {
+    auto x = reg_ & Msbs;
+    return (~x + (x >> 7)) & ~Lsbs;
+  }
+
+  friend void BestFmt(auto& fmt, group_scalar g) {
+    ctrl bytes[sizeof(group_sse2)];
+    best::span(bytes).copy_from(best::span(&g, 1).as_bytes());
+
+    bool first = true;
+    for (auto byte : bytes) {
+      if (!std::exchange(first, false)) { fmt.write(" "); }
+      fmt.format("{}", byte);
+    }
+  }
+
+ private:
+  static constexpr uint64_t Msbs = 0x8080808080808080;
+  static constexpr uint64_t Lsbs = 0x0101010101010101;
+  static constexpr uint64_t Gaps = ~Lsbs >> 8;
+
+  uint64_t reg_;
+};
+
+#if BEST_SSE2
+using group = group_sse2;
+#else
+using group = group_scalar;
+#endif
+
+constexpr size_t mirror(size_t idx, size_t cloned, size_t hard) {
+  // This is intentionally branchless. If `i < kWidth`, it will write to the
+  // cloned bytes as well as the "real" byte; otherwise, it will store `h`
+  // twice.
+  //
+  // We want to map all values n < sizeof(group) to mask - n. Subtracting
+  // off sizeof(group) produces negative values only for the values of interest;
+  // for these values, `(idx - cloned) & mask` is `mask - (cloned - idx)`. We
+  // can then add (cloned & mask) to shift everything up.
+  size_t mask = hard - 1;
+  return ((idx - cloned) & mask) + (cloned);
+}
+
+// A quadratic probe sequence.
+//
+// Currently, the sequence is a triangular progression of the form
+// ```
+// p(i) := kWidth/2 * (i^2 - i) + hash (mod mask + 1)
+// ```
+BEST_INLINE_ALWAYS auto probe(auto& table, const void* ctrl, hash h,
+                              size_t hard, auto cb) {
+  size_t mask = hard - 1;
+  size_t offset = h.h1 & mask;
+  size_t index = 0;
+
+  best::prefetch_for_read<best::prefetch_locality::L3>(ctrl);
+  while (true) {
+    auto g = group::load(ctrl, offset);
+    auto got = cb(offset, g);
+    if (best::likely(got.has_value())) { return *got; }
+
+    index += sizeof(group);
+    offset += index;
+    offset &= mask;
+
+    best::debug_must(index < hard, "full table:\n{}", table.debug(false));
+  }
+}
+
+// The capacity of a table.
+class capacity final {
+ public:
+  capacity() = default;
+
+  // Constructs a new layout for the given minimum number of elements.
+  explicit capacity(size_t at_least) {
+    hard = at_least + at_least / 7;
+    hard =
+      best::checked_next_pow2(hard).expect("map size too large: {}", at_least);
+    hard = best::max(hard, sizeof(group));
+    reset_soft();
+  }
+
+  // The number of groups this in this table's ctrl array.
+  size_t group_count() const { return hard / size_of<group> + 1; }
+
+  // Returns the layout for the backing array.
+  template <typename K, typename V>
+  best::layout layout() const {
+    if constexpr (best::is_empty<V>) {
+      return best::layout::of_struct({
+        best::layout::of<group>().repeat(group_count()),
+        best::layout::of<K>().repeat(hard),
+        best::layout::of<char>(),
+      });
+    } else {
+      return best::layout::of_struct({
+        best::layout::of<group>().repeat(group_count()),
+        best::layout::of<K>().repeat(hard),
+        best::layout::of<V>().repeat(hard),
+      });
+    }
+  }
+
+  template <typename K>
+  size_t keys_offset() const {
+    auto ctrl = best::layout::of<group>().repeat(group_count());
+    return best::round_up_to_pow2(ctrl, align_of<K>);
+  }
+
+  template <typename K, typename V>
+  size_t values_offset() const {
+    auto keys = best::layout::of_struct({
+      best::layout::of<group>().repeat(group_count()),
+      best::layout::of<K>().repeat(hard),
+    });
+    return best::round_up_to_pow2(keys, align_of<V>);
+  }
+
+  void reset_soft() {
+    soft = hard - hard / 8;  // soft = hard * 7/8
+  }
+
+  // hard is always a power of 2; soft is the number of slots left before a
+  // rehash needs to happen.
+  size_t soft{}, hard{};
+};
+
+// The heap-backed array for a table. This is essentially the whole table
+// except for the size and the policy.
+template <typename K, typename V>
+class array final {
+ public:
+  array() = default;
+  explicit array(best::ptr<void> base, capacity cap) : cap_(cap) {
+    size_t ctrl_count = cap.group_count() * sizeof(group);
+
+    ctrl_ = base.template cast<table_internal::ctrl>().raw();
+    keys_ = ctrl_.template skip<K>(ctrl_count);
+    reset_ctrl();
+  }
+
+  table_internal::ctrl ctrl(size_t n) const { return *ctrl_.offset(n); }
+  void set_ctrl(size_t n, table_internal::ctrl c) {
+    if (ctrl(n) == table_internal::ctrl::Empty) { --cap_.soft; }
+
+    *ctrl_.offset(n) = c;
+    *ctrl_.offset(mirror(n, sizeof(group), cap_.hard)) = c;
+  }
+
+  best::ptr<K> key(size_t idx) const { return keys_ + idx; }
+  best::ptr<V> value(size_t idx) const {
+    auto ptr = keys_.template skip<V>(cap_.hard);
+    if constexpr (!best::is_empty<V>) { ptr += idx; }
+    return ptr;
+  }
+
+  const capacity& cap() const { return cap_; }
+  capacity& cap() { return cap_; }
+
+  auto* ptr() const { return ctrl_.raw(); }
+
+  void reset_ctrl() {
+    ctrl_.fill(table_internal::ctrl::Empty.bits,
+               cap_.group_count() * sizeof(group));
+  }
+
+  void destroy() {
+    if (ctrl_ == nullptr) { return; }
+
+    auto keys = keys_;
+    auto values = keys.template skip<V>(cap_.hard);
+
+    auto cur = ctrl_, end = ctrl_ + cap_.hard;
+    do {
+      if (cur->is_occupied()) {
+        keys.destroy();
+        values.destroy();
+      }
+
+      ++cur;
+      ++keys;
+      if constexpr (!best::is_empty<V>) { ++values; }
+    } while (cur != end);
+  }
+
+  BEST_INLINE_ALWAYS size_t vacant_unchecked(hash hash) const {
+    return best::table_internal::probe(  //
+      *this, ptr(), hash, cap().hard,
+      [&](size_t base, group g) -> best::option<size_t> {
+        return g.match_vacant().next().map(
+          [&](auto i) { return (base + i) & (cap().hard - 1); });
+      });
+  }
+
+  BEST_INLINE_ALWAYS best::option<size_t> vacant(hash hash) const {
+    if (ptr() == nullptr) { return best::none; }
+
+    size_t idx = vacant_unchecked(hash);
+    if (cap().soft == 0 && !ctrl(idx).is_tombstone()) { return best::none; }
+
+    return idx;
+  }
+
+  best::strbuf debug(bool) const {
+    best::strbuf out =
+      best::format("type: {}\narray: {:p}, {}/{}\n",
+                   best::type_names::of<array>.path_with_params(), ptr(),
+                   cap().soft, cap().hard);
+
+    if (ptr() == nullptr) { return out; }
+
+    out.push("ctrl:");
+    for (auto i : best::bounds{.count = cap().group_count()}) {
+      i *= sizeof(group);
+      best::format(out, "\n  {:p}: {:?}", ptr() + i, group::load(ptr(), i));
+    }
+    out.push(" (mirrored)\n");
+    return out;
+  }
+
+ private:
+  best::ptr<table_internal::ctrl> ctrl_;
+  best::ptr<K> keys_;
+  capacity cap_;
+};
+
+}  // namespace best::table_internal
+
+#endif  // BEST_CONTAINER_INTERNAL_TABLE_H_

--- a/best/container/object.h
+++ b/best/container/object.h
@@ -26,6 +26,7 @@
 
 #include "best/base/ord.h"
 #include "best/base/tags.h"
+#include "best/hash/hash.h"
 #include "best/memory/ptr.h"
 #include "best/meta/init.h"
 #include "best/meta/traits/empty.h"
@@ -203,6 +204,13 @@ class object final {
   }
   constexpr friend void BestFmtQuery(auto& query, object*) {
     query = query.template of<T>;
+  }
+
+  template <best::hash_state State>
+  constexpr friend void BestHash(best::hasher<State>& h, const object& value)
+    requires requires { h.write(value.or_empty()); }
+  {
+    h.write(value.or_empty());
   }
 
  public:

--- a/best/container/option.h
+++ b/best/container/option.h
@@ -26,6 +26,7 @@
 #include "best/base/fwd.h"
 #include "best/base/tags.h"
 #include "best/container/choice.h"
+#include "best/hash/hash.h"
 #include "best/log/internal/crash.h"
 #include "best/log/location.h"
 #include "best/meta/init.h"
@@ -78,6 +79,12 @@ concept is_option = requires {
 template <is_option T>
 using option_type = typename best::as_auto<T>::type;
 
+namespace option_internal {
+// A helper for threading formatting into option::check_ok. The corresponding
+// definition lives in format.h.
+struct fmt;
+};  // namespace option_internal
+
 /// # `best::option<T>`
 ///
 /// An optional value.
@@ -129,8 +136,8 @@ class option final {
 
   template <typename U>
   static constexpr bool not_forbidden_conversion =
-    (!best::same<best::in_place_t, best::as_auto<U>>)&&  //
-    (!best::same<option, best::as_auto<U>>)&&            //
+    (!best::same<best::in_place_t, best::as_auto<U>>) &&  //
+    (!best::same<option, best::as_auto<U>>) &&            //
     (!best::same<bool, best::un_qual<T>>);
 
  public:
@@ -267,14 +274,15 @@ class option final {
   /// This constructor is intended for constructing options that contain
   /// values with troublesome constructors.
   template <typename... Args>
-  constexpr explicit option(best::in_place_t, Args&&... args)
-    requires best::constructible<T, Args&&...>
+  constexpr explicit(sizeof...(Args) != 1)
+    option(best::in_place_t, Args&&... args)
+      requires best::constructible<T, Args&&...>
     : BEST_OPTION_IMPL_(best::index<1>, BEST_FWD(args)...) {}
 
   template <typename E, typename... Args>
-  constexpr explicit option(best::in_place_t, std::initializer_list<E> il,
-                            Args&&... args)
-    requires best::constructible<T, std::initializer_list<E>, Args&&...>
+  constexpr explicit(sizeof...(Args) != 1)
+    option(best::in_place_t, std::initializer_list<E> il, Args&&... args)
+      requires best::constructible<T, std::initializer_list<E>, Args&&...>
     : BEST_OPTION_IMPL_(best::index<1>, il, BEST_FWD(args)...) {}
 
   /// # `option::is_empty()`
@@ -350,6 +358,27 @@ class option final {
   constexpr ref value(best::location loc = best::here) &;
   constexpr crref value(best::location loc = best::here) const&&;
   constexpr rref value(best::location loc = best::here) &&;
+
+ private:
+  template <typename... Args>
+  using format_template = best::format_internal::templ<  //
+    format_spec, best::dependent<Args, Args...>...>;
+
+ public:
+  /// # `option::expect()`.
+  ///
+  /// Extracts the value of this option. Crashes with the given message.
+  template <typename... Args>
+  constexpr cref expect(format_template<Args...> templ,
+                        const Args&... args) const&;
+  template <typename... Args>
+  constexpr ref expect(format_template<Args...> templ, const Args&... args) &;
+  template <typename... Args>
+  constexpr crref expect(format_template<Args...> templ,
+                         const Args&... args) const&&;
+  template <typename... Args>
+  constexpr crref expect(format_template<Args...> templ,
+                         const Args&... args) &&;
 
   /// # `option::value_or(...)`
   ///
@@ -680,6 +709,13 @@ class option final {
     query.requires_debug = true;
   }
 
+  template <best::hash_state State>
+  constexpr friend void BestHash(best::hasher<State>& h, const option& value)
+    requires best::hashable<T>
+  {
+    h.write(value.BEST_OPTION_IMPL_);
+  }
+
   // Conversions w/ simple_option.
  private:
   using objT = best::select<best::is_object<T>, T, best::empty>;
@@ -757,6 +793,12 @@ class option final {
     if (best::unlikely(is_empty())) {
       crash_internal::crash({"unwrapped a best::none", loc});
     }
+  }
+
+  template <typename... Args, typename F = option_internal::fmt>
+  constexpr void check_ok(format_template<Args...> templ,
+                          const Args&... args) const {
+    if (best::unlikely(is_empty())) { F::wtf(templ, args...); }
   }
 
   constexpr const auto& impl() const& { return BEST_OPTION_IMPL_; }
@@ -868,6 +910,35 @@ constexpr option<T>::crref option<T>::value(best::location loc) const&& {
 template <typename T>
 constexpr option<T>::rref option<T>::value(best::location loc) && {
   return check_ok(loc),
+         BEST_MOVE(*this).value(unsafe("check_ok() called before this"));
+}
+
+template <typename T>
+template <typename... Args>
+constexpr option<T>::cref option<T>::expect(format_template<Args...> templ,
+                                            const Args&... args) const& {
+  return check_ok(templ, args...),
+         value(unsafe("check_ok() called before this"));
+}
+template <typename T>
+template <typename... Args>
+constexpr option<T>::ref option<T>::expect(format_template<Args...> templ,
+                                           const Args&... args) & {
+  return check_ok(templ, args...),
+         value(unsafe("check_ok() called before this"));
+}
+template <typename T>
+template <typename... Args>
+constexpr option<T>::crref option<T>::expect(format_template<Args...> templ,
+                                             const Args&... args) const&& {
+  return check_ok(templ, args...),
+         BEST_MOVE(*this).value(unsafe("check_ok() called before this"));
+}
+template <typename T>
+template <typename... Args>
+constexpr option<T>::crref option<T>::expect(format_template<Args...> templ,
+                                             const Args&... args) && {
+  return check_ok(templ, args...),
          BEST_MOVE(*this).value(unsafe("check_ok() called before this"));
 }
 

--- a/best/container/result.h
+++ b/best/container/result.h
@@ -121,9 +121,9 @@ class [[nodiscard(
   template <typename U>
   static constexpr bool cannot_init_from =
     ((!best::constructible<T, const U&> && !best::constructible<T, U&&>) ||
-     best::is_void<T>)&&((!best::constructible<E, const U&> &&
-                          !best::constructible<E, U&&>) ||
-                         best::is_void<E>);
+     best::is_void<T>) &&
+    ((!best::constructible<E, const U&> && !best::constructible<E, U&&>) ||
+     best::is_void<E>);
 
  public:
   /// Helper type aliases.
@@ -390,6 +390,13 @@ class [[nodiscard(
       return (Q::template of<T>.uses_method(r) &&
               Q::template of<E>.uses_method(r));
     };
+  }
+
+  template <best::hash_state State>
+  constexpr friend void BestHash(best::hasher<State>& h, const result& value)
+    requires best::hashable<T> && best::hashable<E>
+  {
+    h.write(value.BEST_RESULT_IMPL_);
   }
 
  private:

--- a/best/container/row.h
+++ b/best/container/row.h
@@ -25,8 +25,10 @@
 #include "best/base/tags.h"
 #include "best/container/internal/row.h"
 #include "best/container/object.h"
+#include "best/hash/hash.h"
 #include "best/meta/init.h"
 #include "best/meta/tlist.h"
+#include "best/meta/traits/refs.h"
 
 //! A product type, like `std::tuple`.
 //!
@@ -214,6 +216,14 @@ class row final
   constexpr best::row<best::as_ref<Elems>...> as_ref() &;
   constexpr best::row<best::as_rref<const Elems>...> as_ref() const&&;
   constexpr best::row<best::as_rref<Elems>...> as_ref() &&;
+
+  /// # `row::copied()`
+  ///
+  /// Copies a row of values copied from this row.
+  constexpr best::row<best::as_auto<Elems>...> copied() const&;
+  constexpr best::row<best::as_auto<Elems>...> copied() &;
+  constexpr best::row<best::as_auto<Elems>...> copied() const&&;
+  constexpr best::row<best::as_auto<Elems>...> copied() &&;
 
   /// # `row[index<n>]`, `row[best::values<bounds{...}>]`
   ///
@@ -511,6 +521,13 @@ class row final
     };
   }
 
+  template <best::hash_state State>
+  constexpr friend void BestHash(best::hasher<State>& h, const row& value)
+    requires (best::hashable<Elems> && ...)
+  {
+    value.each([&](const auto& x) { h.write(x); });
+  }
+
   // Comparisons.
   template <typename... Us>
   constexpr bool operator==(const row<Us...>& that) const
@@ -597,6 +614,31 @@ template <typename... A>
 constexpr best::row<best::as_rref<A>...> row<A...>::as_ref() && {
   return BEST_MOVE(*this).apply([](auto&&... args) {
     return best::row<best::as_rref<A>...>(BEST_FWD(args)...);
+  });
+}
+
+template <typename... A>
+constexpr best::row<best::as_auto<A>...> best::row<A...>::copied() const& {
+  return apply([](auto&&... args) {
+    return best::row<best::as_auto<A>...>(BEST_FWD(args)...);
+  });
+}
+template <typename... A>
+constexpr best::row<best::as_auto<A>...> best::row<A...>::copied() & {
+  return apply([](auto&&... args) {
+    return best::row<best::as_auto<A>...>(BEST_FWD(args)...);
+  });
+}
+template <typename... A>
+constexpr best::row<best::as_auto<A>...> best::row<A...>::copied() const&& {
+  return BEST_MOVE(*this).apply([](auto&&... args) {
+    return best::row<best::as_auto<A>...>(BEST_FWD(args)...);
+  });
+}
+template <typename... A>
+constexpr best::row<best::as_auto<A>...> best::row<A...>::copied() && {
+  return BEST_MOVE(*this).apply([](auto&&... args) {
+    return best::row<best::as_auto<A>...>(BEST_FWD(args)...);
   });
 }
 

--- a/best/container/table.h
+++ b/best/container/table.h
@@ -954,16 +954,18 @@ best::strbuf table<K, V, P>::debug(bool include_entries) const {
     best::format(out, "  {:p}: {:?}\n", key, best::make_formattable(*key));
   }
 
-  if constexpr (best::is_empty<V>) { return out; }
-  out.push("values:\n");
-  for (auto i : best::bounds{.count = raw_.cap().hard}) {
-    auto value = raw_.value(i);
-    if (raw_.ctrl(i).is_vacant()) {
-      best::format(out, "  {:p}: ---\n", value);
-      continue;
-    }
+  if constexpr (!best::is_empty<V>) {
+    out.push("values:\n");
+    for (auto i : best::bounds{.count = raw_.cap().hard}) {
+      auto value = raw_.value(i);
+      if (raw_.ctrl(i).is_vacant()) {
+        best::format(out, "  {:p}: ---\n", value);
+        continue;
+      }
 
-    best::format(out, "  {:p}: {:?}\n", value, best::make_formattable(*value));
+      best::format(out, "  {:p}: {:?}\n", value,
+                   best::make_formattable(*value));
+    }
   }
 
   return out;

--- a/best/container/table.h
+++ b/best/container/table.h
@@ -1,0 +1,973 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_CONTAINER_TABLE_H_
+#define BEST_CONTAINER_TABLE_H_
+
+#include "best/base/fwd.h"
+#include "best/base/hint.h"
+#include "best/base/tags.h"
+#include "best/base/unsafe.h"
+#include "best/container/internal/table.h"
+#include "best/container/option.h"
+#include "best/hash/hash.h"
+#include "best/iter/bounds.h"
+#include "best/log/location.h"
+#include "best/log/wtf.h"
+#include "best/memory/allocator.h"
+#include "best/memory/layout.h"
+#include "best/meta/init.h"
+#include "best/meta/traits/empty.h"
+#include "best/meta/traits/pairs.h"
+#include "best/meta/traits/refs.h"
+#include "best/meta/traits/types.h"
+#include "best/text/format.h"
+
+namespace best {
+/// # `best::no_insert`
+///
+/// Type tag for marking a `best::table::entry` as non-inserting.
+struct no_insert final {};
+
+template <typename Table, typename Q = best::no_insert>
+class table_entry;
+
+/// # `best::table<K, V>`
+///
+/// `best::table` is a Swisstable implementation, a generic hash table type that
+/// can be used as either a map or a set.
+///
+/// The API is radically different from that of `std::unordered_map`, which it
+/// replaces. Instead of having a variety of lookup operations, `best::table`
+/// has exactly one: `operator[]`. Depending on which overload is picked, this
+/// will return an accessor for the corresponding entry (sort of like an
+/// enhanced `best::option<best::row<K, V>>`); the mutable version is
+/// `best::table::inserter`, which can be used to create an entry in the table.
+///
+/// For example, inserting a value into the table looks like this:
+///
+/// ```
+/// best::table<int, best::strbuf> ints;
+/// ints[42].insert("hello!");
+/// ```
+///
+/// Removal is similar: `ints[42].remove()`, which move the associated entry
+/// out of the map. Accessing members of a value is as simple as
+/// `my_table[k]->foo()`, assuming `k` is present. Operating on possibly absent
+/// members has a clean idiom:
+///
+/// ```
+/// if (auto v = my_table[k]) {
+///   v->do_something();
+/// }
+/// ```
+///
+/// When `V` is `void`, this type takes on a set-like interface. Almost
+/// everything is the same, except that `operator*` and `operator->` on an entry
+/// will operate on the key rather than the value.
+template <typename K, typename V = void,
+          best::abridged Policy = best::abridge<best::table_internal::policy<>>>
+class BEST_RELOCATABLE table final {
+ private:
+  using policy = best::unabridge<Policy>;
+  using group = best::table_internal::group;
+  using ctrl = best::table_internal::ctrl;
+
+ public:
+  using key_type = K;
+  using value_type = V;
+  using identity = policy::identity;
+  using hash_state = policy::hash_state;
+  using allocator = policy::allocator;
+
+  static_assert(best::hash_identity<identity, K>);
+
+  using key_cref = best::as_ref<const key_type>;
+  using key_ref = best::as_ref<key_type>;
+  using key_crref = best::as_rref<const key_type>;
+  using key_rref = best::as_rref<key_type>;
+  using key_cptr = best::as_raw_ptr<const key_type>;
+  using key_ptr = best::as_raw_ptr<key_type>;
+
+  using value_cref = best::as_ref<const value_type>;
+  using value_ref = best::as_ref<value_type>;
+  using value_crref = best::as_rref<const value_type>;
+  using value_rref = best::as_rref<value_type>;
+  using value_cptr = best::as_raw_ptr<const value_type>;
+  using value_ptr = best::as_raw_ptr<value_type>;
+
+  // clang-format off
+  /// # `table::with_identity<I>`, `table::with_hash<H>`, `table::with_allocator<A>`
+  ///
+  /// Aliases for creating a new table type with the given configuration
+  /// changes.
+  // clang-format on
+  template <best::hash_identity<K> I>
+  using with_identity = best::table<
+    K, V,
+    best::abridge<best::table_internal::policy<I, hash_state, allocator>>>;
+  template <best::hash_state H>
+  using with_hash = best::table<
+    K, V, best::abridge<best::table_internal::policy<identity, H, allocator>>>;
+  template <best::allocator A>
+  using with_allocator = best::table<
+    K, V, best::abridge<best::table_internal::policy<identity, hash_state, A>>>;
+
+  /// # `table::const_entry`, `table::entry`
+  ///
+  /// This tables's entry types.
+  using const_entry = best::table_entry<const table>;
+  using entry = best::table_entry<table>;
+
+  /// # `table::inserter`
+  ///
+  /// This table's inserter type, used for performing mutation operations.
+  template <typename Q>
+  using inserter = best::table_entry<table, Q>;
+
+  /// # `table::table()`
+  ///
+  /// Constructs a new empty table.
+  table() = default;
+  explicit table(identity identity, allocator allocator = {})
+    : identity_(BEST_MOVE(identity)), alloc_(BEST_MOVE(allocator)) {}
+
+  /// # `table::table { ... }`
+  ///
+  /// Constructs a new empty table with the given elements.
+  table(std::initializer_list<best::row<K, V>> il) requires (!best::is_void<V>)
+  {
+    reserve(il.size());
+    for (const auto& [k, v] : il) { query(k).insert(v); }
+  }
+  template <typename K2>
+  table(std::initializer_list<K2> il) requires best::is_void<V>
+  {
+    reserve(il.size());
+    for (const auto& k : il) { query(k).insert(); }
+  }
+
+  /// # `vec::vec(iterator)`
+  ///
+  /// Constructs a vector by emptying an iterator.
+  template <is_iter Iter>
+  explicit table(Iter&& iter)
+    requires (!best::is_void<V>) &&
+             best::constructible<K, best::first_in<best::iter_type<Iter>>> &&
+             best::constructible<V, best::second_in<best::iter_type<Iter>>>
+  {
+    reserve(iter.size_hint().lower);
+    for (auto&& [k, v] : iter) { query(BEST_FWD(k)).insert(BEST_FWD(v)); }
+  }
+  template <is_iter Iter>
+  explicit table(Iter&& iter)
+    requires best::is_void<V> && best::constructible<K, best::iter_type<Iter>>
+  {
+    reserve(iter.size_hint().lower);
+    for (auto&& k : iter) { query(BEST_FWD(k)).insert(); }
+  }
+
+  /// # `table::table(table)`
+  ///
+  /// Copy and move constructors.
+  table(const table&) requires best::copyable<K> && best::copyable<V>;
+  table& operator=(const table&)  //
+    requires best::copyable<K> && best::copyable<V>;
+  table(table&&);
+  table& operator=(table&&);
+
+  /// # `table::~table()`
+  ///
+  /// Destroys this table.
+  ~table() {
+    raw_.destroy();
+    free();
+  }
+
+  /// # `table::size()`
+  ///
+  /// Returns the number of entries in the table.
+  size_t size() const { return size_; }
+
+  /// # `table::capacity()`
+  ///
+  /// Returns the table's capacity, i.e. the total number of entries it can
+  /// contain before a rehash happens.
+  size_t capacity() const { return size_ + raw_.cap().soft; }
+
+  /// # `table::operator[]`
+  ///
+  /// Extracts an entry from the table using the given query.
+  ///
+  /// This will not trigger an insertion if the key is not present; to do so,
+  /// use the member functions on the returned `table::inserter`.
+  template <typename Q>
+  const_entry operator[](Q&& query) const
+    requires best::hash_identity<identity, K, Q>;
+  template <typename Q>
+  inserter<Q> operator[](Q&& query) requires best::hash_identity<identity, K, Q>
+  ;
+
+  /// # `table::query()`
+  ///
+  /// Identical to `operator[]`; exists only to be used when accessing via `->`.
+  /// Prefer `operator[]` in general.
+  template <typename Q>
+  const_entry query(Q&& query) const
+    requires best::hash_identity<identity, K, Q>
+  {
+    return operator[](BEST_FWD(query));
+  }
+  template <typename Q>
+  inserter<Q> query(Q&& query) requires best::hash_identity<identity, K, Q>
+  {
+    return operator[](BEST_FWD(query));
+  }
+
+  /// # `table::contains()`
+  ///
+  /// Returns whether an entry exists in this table matching the given query.
+  template <typename Q>
+  bool contains(Q&& query) const {
+    return this->query(BEST_FWD(query)).is_occupied();
+  }
+
+  /// # `table::const_iterator`, `table::iterator`
+  ///
+  /// This tables's iterator types.
+  using const_iterator = best::iter<table_internal::iter_impl<const table>>;
+  using iterator = best::iter<table_internal::iter_impl<table>>;
+
+  /// # `table::iter()`, `table::begin()`, `table::end()`.
+  ///
+  /// Tables are iterable; the yielded values are entries, which support
+  /// structured bindings, but, in the case of the non-const iterator, can also
+  /// be used for removal.
+  const_iterator iter() const {
+    return const_iterator(table_internal::iter_impl<const table>(this));
+  }
+  iterator iter() { return iterator(table_internal::iter_impl<table>(this)); }
+  auto begin() const { return iter().into_range(); }
+  auto begin() { return iter().into_range(); }
+  auto end() const { return best::iter_range_end{}; }
+
+  /// # `table::clear()`
+  ///
+  /// Destroys all entries in the table without freeing capacity. This will
+  /// always be faster than calling `e.remove()` in a loop.
+  void clear() {
+    raw_.destroy();
+    raw_.reset_ctrl();
+    raw_.cap().reset_soft();
+    size_ = 0;
+  }
+
+  /// # `table::reserve()`
+  ///
+  /// Ensures that inserting another `capacity` elements will not trigger a
+  /// rehash of the table.
+  void reserve(size_t capacity);
+
+  /// # `table::rehash()`
+  ///
+  /// Shuffles around the internal hash table data structure to improve future
+  /// lookups. May cause reallocation.
+  void rehash();
+
+  /// # `table::hash_value`
+  ///
+  /// A hash calculated for some query. See `table::hash()`.
+  class hash_value final {
+   public:
+    constexpr hash_value() = default;
+
+   private:
+    friend table;
+    template <typename, typename>
+    friend class best::table_entry;
+
+    table_internal::hash h_;
+  };
+
+  /// # `table::hash()`
+  ///
+  /// Calculates the hash for some query.
+  /// The returned hash becomes invalid if the table is resized or rehashed.
+  template <typename Q>
+  requires best::hash_identity<identity, K, Q>
+  hash_value hash(const Q& query) const {
+    return hash(query, raw_.ptr());
+  }
+
+  /// # `table::debug()`
+  ///
+  /// Dumps debugging information about this table.
+  best::strbuf debug(bool include_entries = true) const;
+
+ private:
+  template <typename, typename>
+  friend class best::table_entry;
+  template <typename>
+  friend class best::table_internal::iter_impl;
+
+  template <typename Q>
+  requires best::hash_identity<identity, K, Q>
+  hash_value hash(const Q& query, const void* ctrl) const {
+    hash_value h;
+    h.h_ = best::table_internal::hash::compute<K, hash_state>(query, identity_,
+                                                              ctrl);
+    return h;
+  }
+
+  best::option<size_t> search(hash_value hash, const auto& query) const;
+  best::row<size_t, bool> maybe_preinsert(hash_value hash, const auto& query);
+  size_t preinsert(hash_value hash, const auto& query);
+
+  template <bool relo>
+  table_internal::array<K, V> rehash_to(table_internal::capacity new_cap,
+                                        const table& target) const;
+
+  void free() {
+    if (raw_.ptr() != nullptr) {
+      alloc_.dealloc(best::ptr(raw_.ptr()), raw_.cap().template layout<K, V>());
+    }
+  }
+
+  table_internal::array<K, V> raw_{};
+  size_t size_{};
+  [[no_unique_address]] identity identity_;
+  [[no_unique_address]] allocator alloc_;
+};
+
+/// # `best::table_entry<Table, Query>`
+///
+/// An entry in a table (a bucket). All operations on the table use entries
+/// in some way. Entries are ephemeral; whenever a rehash occurs, all entries
+/// returned by a table are invalidated.
+///
+/// To obtain a value of this type, use `best::table::operator[]`.
+template <typename Table, typename Query>
+class table_entry final {
+ private:
+  using group = best::table_internal::group;
+  using ctrl = best::table_internal::ctrl;
+
+ public:
+  using table = Table;
+  static constexpr bool is_const = best::is_const<table>;
+
+  using key_type = table::key_type;
+  using value_type = table::value_type;
+  using query_type = Query;
+
+  using kref = table::key_cref;
+  using vref = best::select<is_const, typename table::value_cref,
+                            typename table::value_ref>;
+
+  static constexpr bool CanInsert = !best::same<Query, best::no_insert>;
+
+  /// # `table_entry::table_entry()`
+  ///
+  /// Creates a new vacant entry which cannot be inserted with. Attempting to
+  /// insert
+  constexpr table_entry() requires best::constructible<query_type>
+    : idx_(-1) {}
+
+  /// # `table_entry::is_vacant()`, `table_entry::is_occupied()`
+  ///
+  /// Whether this entry is currently occupied by a pair or not.
+  bool is_vacant() const { return best::to_signed(idx_) < 0; }
+  bool is_occupied() const { return !is_vacant(); }
+
+  /// # `table_entry::pair()`, `table_entry::key()`, `table_entry::value()`
+  ///
+  /// If the entry is occupied, returns the key/value for the entry.
+  best::option<kref> key() const;
+  best::option<vref> value() const;
+  best::option<best::row<kref, vref>> pair() const;
+
+  /// # `table_entry::value_or()`
+  ///
+  /// Forwards to `value().value_or()`, which comes off as very silly otherwise.
+  template <typename... Args>
+  decltype(auto) value_or(Args&&... args) const {
+    return value().value_or(BEST_FWD(args)...);
+  }
+
+  /// # `table_entry::operator*`, `table_entry::operator->`
+  ///
+  /// Allow access to the value. Panic if this entry is vacant.
+  decltype(auto) operator*() const {
+    check_occupied();
+    if constexpr (best::is_void<value_type>) {
+      return *key();
+    } else {
+      return *value();
+    }
+  }
+  auto* operator->() const {
+    check_occupied();
+    if constexpr (best::is_void<value_type>) {
+      return key().operator->();
+    } else {
+      return value().operator->();
+    }
+  }
+  explicit operator bool() const { return is_occupied(); }
+
+  /// # `table_entry::insert()`, `table_entry::or_insert()`
+  ///
+  /// Inserts a new value, constructing it in-place using the given arguments.
+  /// `insert()` does so unconditionally, destroying an existing value in the
+  /// process. `or_insert()` only does so if this entry is vacant.
+  ///
+  /// Returns a reference to the inserted value.
+  template <typename... Args>
+  vref insert(Args&&... args) requires CanInsert;
+  template <typename... Args>
+  vref or_insert(Args&&... args) requires CanInsert;
+
+  /// # `option::or_insert([] { ... })`
+  ///
+  /// Like `best::option::value_or([] { ... })`.
+  template <typename... Args>
+  vref or_insert(best::callable<value_type()> auto&& or_else) requires CanInsert
+  ;
+
+  operator best::table_entry<table>() const {
+    return best::table_entry<table>(table_, idx_);
+  }
+
+  /// # `table_entry::remove()`, `table_entry::erase()`
+  ///
+  /// Removes this entry, if it was occupied. `erase` is like `remove`, but it
+  /// does not return a value.
+  best::option<best::row<key_type, value_type>> remove() &&;
+  void erase() &&;
+
+ private:
+  friend table;
+  template <typename, typename>
+  friend class best::table_entry;
+  template <typename>
+  friend class best::table_internal::iter_impl;
+
+  explicit table_entry(table* table, size_t idx, table::hash_value hash,
+                       best::object<Query> query) requires CanInsert
+    : table_(table), idx_(idx), insert_info_{hash, BEST_MOVE(query)} {}
+
+  explicit table_entry(table* table, size_t idx) requires (!CanInsert)
+    : table_(table), idx_(idx) {}
+
+  template <size_t i>
+  requires (i < 2)
+  friend decltype(auto) get(const table_entry& entry,
+                            best::location loc = best::here) {
+    entry.check_occupied(loc);
+    if constexpr (i == 0) {
+      return entry.key().value(best::unsafe{"checked above"});
+    } else {
+      return entry.value().value(best::unsafe{"checked above"});
+    }
+  }
+
+  void check_occupied(best::location loc = best::here) const {
+    if (best::unlikely(is_vacant())) {
+      if constexpr (CanInsert) {
+        best::wtf({"accessed a vacant table::entry with query ({:?})", loc},
+                  best::make_formattable(insert_info_.query.or_empty()));
+      }
+      best::wtf({"accessed a vacant table::entry", loc});
+    }
+  }
+
+  best::row<key_type, value_type> move_pair();
+  void destroy_pair();
+
+  static constexpr size_t Full = ~(best::max_of<size_t> >> 1);
+
+  table* table_;
+  size_t idx_;  // Negative if not present in the table. If an insertion
+                // position is known, it is ~ that index. If not, because the
+                // table is at-capacity, this will be Full.
+
+  // Fields necessary to execute an insertion.
+  struct insert_info {
+    table::hash_value hash;
+    best::object<Query> query;
+  };
+  [[no_unique_address]] best::select<CanInsert, insert_info, best::empty>
+    insert_info_;
+};
+}  // namespace best
+
+/* ////////////////////////////////////////////////////////////////////////// *\
+ * ////////////////// !!! IMPLEMENTATION DETAILS BELOW !!! ////////////////// *
+\* ////////////////////////////////////////////////////////////////////////// */
+
+// Enable structured bindings.
+namespace std {
+template <typename T, typename Q>
+struct tuple_size<::best::table_entry<T, Q>> {
+  static constexpr size_t value = 2;
+};
+template <typename T, typename Q>
+struct tuple_element<0, ::best::table_entry<T, Q>> {
+  using type = ::best::table_entry<T, Q>::kref;
+};
+template <typename T, typename Q>
+struct tuple_element<1, ::best::table_entry<T, Q>> {
+  using type = ::best::table_entry<T, Q>::vref;
+};
+}  // namespace std
+
+namespace best {
+template <typename K, typename V, best::abridged P>
+template <typename Q>
+auto table<K, V, P>::operator[](Q&& query) const -> const_entry
+  requires best::hash_identity<identity, K, Q>
+{
+  auto hash = this->hash(query);
+  return const_entry(this, search(hash, query).value_or(-1));
+}
+
+template <typename K, typename V, best::abridged P>
+template <typename Q>
+auto table<K, V, P>::operator[](Q&& query) -> inserter<Q>
+  requires best::hash_identity<identity, K, Q>
+{
+  auto hash = this->hash(query);
+  auto found = search(hash, query);
+  if (!found) {
+    found = raw_.vacant(hash.h_).map([&](auto i) { return ~i; });
+  }
+
+  return inserter<Q>(this, found.value_or(inserter<Q>::Full), hash,
+                     best::object<Q>(best::in_place, BEST_FWD(query)));
+}
+
+template <typename T, typename Q>
+auto table_entry<T, Q>::key() const -> best::option<kref> {
+  if (is_vacant()) { return best::none; }
+
+  return table_->raw_.key(idx_).deref();
+}
+
+template <typename T, typename Q>
+auto table_entry<T, Q>::value() const -> best::option<vref> {
+  if (is_vacant()) { return best::none; }
+
+  if constexpr (best::is_void<value_type>) {
+    return best::option<vref>(best::in_place);
+  } else {
+    return table_->raw_.value(idx_).deref();
+  }
+}
+
+template <typename T, typename Q>
+auto table_entry<T, Q>::pair() const -> best::option<best::row<kref, vref>> {
+  if (is_vacant()) { return best::none; }
+
+  using row = best::row<kref, vref>;
+  if constexpr (best::is_void<value_type>) {
+    return best::option(row{table_->raw_.key(idx_).deref(), {}});
+  } else {
+    return best::option(row{
+      table_->raw_.key(idx_).deref(),
+      table_->raw_.value(idx_).deref(),
+    });
+  }
+}
+
+template <typename T, typename Q>
+auto table_entry<T, Q>::move_pair() -> best::row<key_type, value_type> {
+  using row = best::row<key_type, value_type>;
+  if constexpr (best::is_void<value_type>) {
+    return row{BEST_MOVE(table_->raw_.key(idx_).deref()), {}};
+  } else {
+    return row{
+      BEST_MOVE(table_->raw_.key(idx_).deref()),
+      BEST_MOVE(table_->raw_.value(idx_).deref()),
+    };
+  }
+}
+
+template <typename T, typename Q>
+void table_entry<T, Q>::destroy_pair() {
+  table_->raw_.key(idx_).destroy();
+  if constexpr (!best::is_void<value_type>) {
+    table_->raw_.value(idx_).destroy();
+  }
+}
+
+template <typename T, typename Q>
+template <typename... Args>
+auto table_entry<T, Q>::insert(Args&&... args) -> vref requires CanInsert
+{
+  best::debug_must(table_ != nullptr,
+                   "called insert() on default-constructed best::table_entry");
+
+  if (is_vacant()) { return BEST_MOVE(*this).or_insert(BEST_FWD(args)...); }
+
+  table_->raw_.key(idx_).assign(BEST_MOVE(*insert_info_.query));
+
+  auto value = table_->raw_.value(idx_);
+  value.assign(BEST_FWD(args)...);
+  return *value;
+}
+
+template <typename T, typename Q>
+template <typename... Args>
+auto table_entry<T, Q>::or_insert(Args&&... args) -> vref requires CanInsert
+{
+  best::debug_must(table_ != nullptr,
+                   "called insert() on default-constructed best::table_entry");
+
+  bool vacant = is_vacant();
+  if (vacant) {
+    if (idx_ == Full) {
+      table_->rehash();
+      insert_info_.hash = table_->hash(*insert_info_.query);
+      idx_ = table_->raw_.vacant_unchecked(insert_info_.hash.h_);
+    } else {
+      idx_ = ~idx_;
+    }
+
+    table_->raw_.set_ctrl(idx_, insert_info_.hash.h_.h2);
+    table_->raw_.key(idx_).construct(*BEST_MOVE(insert_info_.query));
+    ++table_->size_;
+  }
+
+  auto ptr = table_->raw_.value(idx_);
+  if (vacant) { ptr.construct(BEST_FWD(args)...); }
+
+  return *ptr;
+}
+
+template <typename T, typename Q>
+auto table_entry<T, Q>::remove() && -> best::option<
+                                      best::row<key_type, value_type>> {
+  best::debug_must(table_ != nullptr,
+                   "called insert() on default-constructed best::table_entry");
+  if (is_vacant()) { return best::none; }
+
+  auto removed = move_pair();
+  BEST_MOVE(*this).erase();
+  return removed;
+}
+
+template <typename T, typename Q>
+void table_entry<T, Q>::erase() && {
+  if (is_vacant()) { return; };
+  destroy_pair();
+
+  table_->size_--;
+  auto next = idx_;
+  auto prev = (idx_ - size_of<group>)&(table_->raw_.cap().hard - 1);
+
+  auto next_empty = group::load(table_->raw_.ptr(), next).match_empty();
+  auto prev_empty = group::load(table_->raw_.ptr(), prev).match_empty();
+
+  bool was_never_full =
+    !next_empty.empty() && !prev_empty.empty() &&
+    next_empty.trailing_zeros() + prev_empty.leading_zeros() < sizeof(group);
+
+  table_->raw_.set_ctrl(idx_, was_never_full ? ctrl::Empty : ctrl::Tombstone);
+  table_->raw_.cap().soft += was_never_full;
+
+  table_ = nullptr;
+  idx_ = -1;
+}
+
+namespace table_internal {
+template <typename Table>
+class iter_impl final {
+  using table = Table;
+
+ public:
+  best::option<best::table_entry<table>> next() {
+    while (cur_ != end_) {
+      auto cur = *cur_++;
+      if (cur.is_occupied()) {
+        --count_;
+        return best::table_entry<table>(table_, cur_ - start_ - 1);
+      }
+    }
+
+    return best::none;
+  }
+
+  best::size_hint size_hint() const {
+    return {.lower = count_, .upper = count_};
+  }
+  size_t count() && { return count_; }
+
+ private:
+  friend table;
+  template <typename, typename>
+  friend class table_entry;
+
+  explicit iter_impl(table* table) : table_(table), count_(table->size_) {
+    start_ = table_->raw_.ptr();
+    cur_ = start_;
+    end_ = start_ + table_->raw_.cap().hard;
+  }
+
+  table* table_;
+  const ctrl *start_, *cur_, *end_;
+  size_t count_;
+};
+}  // namespace table_internal
+
+template <typename K, typename V, best::abridged P>
+table<K, V, P>::table(const table& that)
+  requires best::copyable<K> && best::copyable<V>
+  : table(0, that.identity_, that.alloc_) {
+  *this = that;
+}
+
+template <typename K, typename V, best::abridged P>
+auto table<K, V, P>::operator=(const table& that)
+  -> table& requires best::copyable<K> && best::copyable<V>
+{
+  raw_.destroy();
+  raw_ = that.rehash_to<false>(that.cap_, *this);
+  size_ = that.size_;
+
+  return *this;
+}
+
+template <typename K, typename V, best::abridged P>
+table<K, V, P>::table(table&& that)
+  : raw_(that.raw_),
+    size_(that.size_),
+    identity_(BEST_MOVE(that.identity_)),
+    alloc_(BEST_MOVE(that.alloc_)) {
+  that.raw_ = {};
+  that.size_ = 0;
+}
+
+template <typename K, typename V, best::abridged P>
+auto table<K, V, P>::operator=(table&& that) -> table& {
+  raw_.destroy();
+
+  size_ = that.size_;
+  raw_ = that.raw_;
+  identity_ = BEST_MOVE(that.identity_);
+  alloc_ = BEST_MOVE(that.alloc_);
+
+  that.raw_ = {};
+  that.size_ = 0;
+  return *this;
+}
+
+template <typename K, typename V, best::abridged P>
+void table<K, V, P>::reserve(size_t n) {
+  auto new_size = size() + n;
+  if (new_size <= capacity()) { return; }
+
+  table_internal::capacity new_cap(new_size);
+  auto new_array = rehash_to<true>(new_cap, *this);
+
+  free();
+  raw_ = new_array;
+}
+
+template <typename K, typename V, best::abridged P>
+void table<K, V, P>::rehash() {
+  if (
+    raw_.cap().hard < sizeof(group) ||
+    // See
+    // https://github.com/google/cwisstable/blob/main/cwisstable/internal/raw_table.h#L445.
+    size_ * uint64_t(32) > raw_.cap().hard * uint64_t(25)) {
+    reserve(1);
+    return;
+  }
+
+  for (auto i : best::bounds{.count = raw_.cap().group_count()}) {
+    i *= sizeof(group);
+    group::load(raw_.ptr(), i).prepare_for_rehash().store(raw_.ptr(), i);
+  }
+
+  for (size_t i = 0; i < raw_.cap().hard; ++i) {
+    if (!raw_.ctrl(i).is_tombstone()) { continue; }
+
+    auto old_key = raw_.key(i);
+    auto old_value = raw_.value(i);
+    auto h = hash(*old_key);
+
+    size_t new_i = raw_.vacant_unchecked(h.h_);
+    auto new_key = raw_.key(i);
+    auto new_value = raw_.value(i);
+
+    // Verify if the old and new i fall within the same group wrt the hash.
+    // If they do, we don't need to move the object as it falls already in the
+    // best probe we can.
+    auto mask = raw_.cap().hard - 1;
+    size_t probe_offset = h.h_.h1 & mask;
+    auto probe_index = [probe_offset, mask](size_t i) {
+      return ((i - probe_offset) & mask) / sizeof(group);
+    };
+
+    if (best::likely(probe_index(i) == probe_index(new_i))) {
+      // Don't move.
+      raw_.set_ctrl(i, h.h_.h2);
+      continue;
+    }
+
+    if (raw_.ctrl(new_i).is_empty()) {
+      // Relocate to new slot.
+      raw_.set_ctrl(new_i, h.h_.h2);
+      new_key.relo(old_key);
+      if constexpr (!best::is_void<V>) { new_value.relo(old_value); }
+      raw_.set_ctrl(i, ctrl::Empty);
+
+      continue;
+    }
+
+    best::debug_must(raw_.ctrl(new_i).is_tombstone(),
+                     "corrupt control byte: {:?}", raw_.ctrl(new_i));
+    raw_.set_ctrl(new_i, h.h_.h2);
+
+    // TODO: Swap.
+    best::object<K> tmp{best::in_place, BEST_MOVE(*old_key)};
+    old_key.move_assign(new_key);
+    new_key.move_assign(tmp.as_ptr());
+    if constexpr (!best::is_void<V>) {
+      best::object<V> tmp{best::in_place, BEST_MOVE(*old_value)};
+      old_value.move_assign(new_value);
+      new_value.move_assign(tmp.as_ptr());
+    }
+
+    --i;  // Try again.
+  }
+
+  raw_.cap().reset_soft();
+  raw_.cap().soft -= size_;
+}
+
+template <typename K, typename V, best::abridged P>
+template <bool relo>
+table_internal::array<K, V> table<K, V, P>::rehash_to(
+  table_internal::capacity new_cap, const table& target) const {
+  table_internal::array<K, V> new_raw{
+    target.alloc_.alloc(new_cap.layout<K, V>()),
+    new_cap,
+  };
+
+  for (auto entry : iter()) {
+    size_t idx_rhs = entry.idx_;
+    auto key_rhs = raw_.key(idx_rhs);
+    auto value_rhs = raw_.value(idx_rhs);
+
+    auto hash = target.hash(*key_rhs, new_raw.ptr());
+    size_t idx_lhs = new_raw.vacant_unchecked(hash.h_);
+
+    auto key_lhs = new_raw.key(idx_lhs);
+    auto value_lhs = new_raw.value(idx_lhs);
+
+    if constexpr (relo) {
+      key_lhs.relo(key_rhs);
+    } else {
+      key_lhs.copy(key_rhs);
+    }
+    if constexpr (!best::is_void<V>) {
+      if constexpr (relo) {
+        value_lhs.relo(value_rhs);
+      } else {
+        value_lhs.copy(value_rhs);
+      }
+    }
+
+    new_raw.set_ctrl(idx_lhs, hash.h_.h2);
+  }
+  return new_raw;
+}
+
+template <typename K, typename V, best::abridged P>
+BEST_INLINE_ALWAYS best::option<size_t> table<K, V, P>::search(
+  hash_value hash, const auto& query) const {
+  if (raw_.ptr() == nullptr) { return best::none; }
+
+  return best::table_internal::probe(  //
+    *this, raw_.ptr(), hash.h_, raw_.cap().hard,
+    [&](size_t base, group g) -> best::option<best::option<size_t>> {
+      auto match = g.match(hash.h_.h2);
+      while (auto next = match.next()) {
+        size_t idx = (base + *next) & (raw_.cap().hard - 1);
+        if (best::likely(identity_.equal(*raw_.key(idx), query))) {
+          return {best::in_place, best::option(idx)};
+        }
+      }
+
+      if (best::likely(!g.match_empty().empty())) {
+        return {best::in_place, best::none};
+      }
+
+      return best::none;
+    });
+}
+
+template <typename K, typename V, best::abridged P>
+best::strbuf table<K, V, P>::debug(bool include_entries) const {
+  best::strbuf out =
+    best::format("type: {}\narray: {:p}, {}/{}/{}\n",
+                 best::type_names::of<table>.path_with_params(), raw_.ptr(),
+                 size_, raw_.cap().soft, raw_.cap().hard);
+
+  if (raw_.ptr() == nullptr) { return out; }
+
+  out.push("ctrl:");
+  for (auto i : best::bounds{.count = raw_.cap().group_count()}) {
+    i *= sizeof(group);
+    best::format(out, "\n  {:p}: {:?}", raw_.ptr() + i,
+                 group::load(raw_.ptr(), i));
+  }
+  out.push(" (mirrored)\n");
+
+  if (!include_entries) { return out; }
+
+  out.push("keys:\n");
+  for (auto i : best::bounds{.count = raw_.cap().hard}) {
+    auto key = raw_.key(i);
+    if (raw_.ctrl(i).is_vacant()) {
+      best::format(out, "  {:p}: ---\n", key);
+      continue;
+    }
+
+    best::format(out, "  {:p}: {:?}\n", key, best::make_formattable(*key));
+  }
+
+  if constexpr (best::is_empty<V>) { return out; }
+  out.push("values:\n");
+  for (auto i : best::bounds{.count = raw_.cap().hard}) {
+    auto value = raw_.value(i);
+    if (raw_.ctrl(i).is_vacant()) {
+      best::format(out, "  {:p}: ---\n", value);
+      continue;
+    }
+
+    best::format(out, "  {:p}: {:?}\n", value, best::make_formattable(*value));
+  }
+
+  return out;
+}
+}  // namespace best
+
+#endif  // BEST_CONTAINER_TABLE_H_

--- a/best/container/table_test.cc
+++ b/best/container/table_test.cc
@@ -1,0 +1,229 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#include "best/container/table.h"
+
+#include "best/container/internal/table.h"
+#include "best/test/fodder.h"
+#include "best/test/test.h"
+
+namespace best::table_test {
+using ::best::table_internal::mirror;
+using ::best_fodder::MoveOnly;
+
+// A maximally swisstable-hostile hash implementation.
+struct TerribleHash final {
+  using output = uint64_t;
+  constexpr void write(uint64_t x) { h += x; }
+  constexpr void write(best::span<const char> bytes) {}
+  constexpr output finish() const { return h << 7; }
+
+  uint64_t h = 0;
+};
+
+best::test Mirror = [](auto& t) {
+  t.expect_eq(mirror(0, 4, 4), 4);
+  t.expect_eq(mirror(1, 4, 4), 5);
+  t.expect_eq(mirror(2, 4, 4), 6);
+  t.expect_eq(mirror(3, 4, 4), 7);
+
+  t.expect_eq(mirror(0, 4, 8), 8);
+  t.expect_eq(mirror(1, 4, 8), 9);
+  t.expect_eq(mirror(2, 4, 8), 10);
+  t.expect_eq(mirror(3, 4, 8), 11);
+
+  t.expect_eq(mirror(4, 4, 8), 4);
+  t.expect_eq(mirror(5, 4, 8), 5);
+  t.expect_eq(mirror(6, 4, 8), 6);
+  t.expect_eq(mirror(7, 4, 8), 7);
+};
+
+best::test SmallMap = [](auto& t) {
+  best::table<int, int> m{
+    {1, 2},
+    {3, 4},
+    {5, 6},
+    {5, 7},
+  };
+  best::eprintln("{}", m.debug());
+
+  t.expect_eq(m[1].pair(), best::row(1, 2));
+  t.expect_eq(m[3].pair(), best::row(3, 4));
+  t.expect_eq(m[5].pair(), best::row(5, 7));
+
+  auto entries =
+    m.iter().map([](auto e) { return e.pair()->copied(); }).to_vec();
+  entries->sort([](const auto& e) { return e.first(); });
+
+  t.expect_eq(entries, best::vec<best::row<int, int>>{{1, 2}, {3, 4}, {5, 7}});
+};
+
+best::test SmallSet = [](auto& t) {
+  best::table<int> m{1, 2, 3, 4, 5, 6};
+  best::eprintln("{}", m.debug());
+
+  t.expect(m[1]);
+  t.expect(m[2]);
+  t.expect(m[3]);
+  t.expect(m[4]);
+  t.expect(m[5]);
+  t.expect(m[6]);
+  t.expect(!m[7]);
+
+  auto entries = m.iter().map([](auto e) { return *e; }).to_vec();
+  entries->sort();
+
+  t.expect_eq(entries, best::vec{1, 2, 3, 4, 5, 6});
+};
+
+best::test HammerInts = [](auto& t) {
+  best::table<int, int> m;
+
+  for (int i : best::bounds{.count = 1000}) { m[i].insert(-i); }
+  best::eprintln("{}", m.debug(false));
+  for (int i : best::bounds{.count = 1000}) {
+    t.expect_eq(m[i].pair(), best::row(i, -i));
+  }
+  for (auto i : best::bounds{.count = 1000 / 2}) {
+    t.expect_eq(m[2 * i].remove(), best::row(2 * i, -2 * i));
+  }
+  best::eprintln("{}", m.debug(false));
+  for (auto i : best::bounds{.count = 1000}) {
+    switch (i % 2) {
+      case 0: t.expect_eq(m[i].pair(), best::none); break;
+      case 1: t.expect_eq(m[i].pair(), best::row(i, -i)); break;
+    }
+  }
+  for (auto i : best::bounds{.count = 1000}) {
+    int v = m[i].or_insert(1 - i);
+    t.expect_eq(v, i % 2 == 0 ? 1 - i : -i);
+  }
+  best::eprintln("{}", m.debug(false));
+  for (auto e : m) {
+    auto k = *e.key();
+    switch (k % 2) {
+      case 0: t.expect_eq(*e, 1 - k); break;
+      case 1:
+        t.expect_eq(*e, -k);
+        t.expect_eq(BEST_MOVE(e).remove(), best::row(k, -k));
+        break;
+    }
+  }
+  best::eprintln("{}", m.debug(false));
+  for (auto e : m) {
+    auto k = *e.key();
+    t.expect_eq(k % 2, 0);
+    t.expect_eq(*e, 1 - k);
+  }
+};
+
+best::test Terrible = [](auto& t) {
+  best::table<int>::with_hash<TerribleHash> m;
+
+  for (int i : best::bounds{.count = 100}) { m[i * 2].insert(); }
+  best::eprintln("{}", m.debug());
+
+  for (int i : best::bounds{.count = 200}) {
+    t.expect_eq(m[i].is_occupied(), i % 2 == 0);
+  }
+
+  for (int i : best::bounds{.count = 50}) { m[i * 4 + 2].remove(); }
+  best::eprintln("{}", m.debug());
+
+  for (int i : best::bounds{.count = 200}) {
+    t.expect_eq(m[i].is_occupied(), i % 4 == 0);
+  }
+};
+
+best::test Drain = [](auto& t) {
+  best::table<int>::with_hash<TerribleHash> set(
+    best::bounds{.count = 100}.iter());
+  best::eprintln("{}", set.debug());
+  for (auto e : set) { BEST_MOVE(e).remove(); }
+  best::eprintln("{}", set.debug());
+
+  for (int i : best::bounds{.start = 100, .count = 100}) { set[i].insert(); }
+  best::eprintln("{}", set.debug());
+
+  auto entries = set.iter().map([](auto e) { return *e; }).to_vec();
+  entries->sort();
+  t.expect_eq(entries,
+              best::vec(best::bounds{.start = 100, .count = 100}.iter()));
+};
+
+best::test StringSet = [](auto& t) {
+  best::table<best::strbuf> movies = {
+    best::str("The Phonecian Scheme"),
+    best::str("Beau Is Afraid"),
+    best::str("Twelve Angry Men"),
+    best::str("Final Destination"),
+  };
+
+  t.expect(movies["The Phonecian Scheme"]);
+  t.expect(movies["Beau Is Afraid"]);
+  t.expect(movies["Twelve Angry Men"]);
+  t.expect(movies["Final Destination"]);
+
+  t.expect(!movies["Spaceballs"]);
+  movies[best::str("Spaceballs")].insert();
+  t.expect(movies["Spaceballs"]);
+};
+
+best::test HammerStrings = [](auto& t) {
+  best::table<best::strbuf> strs;
+
+  best::strbuf k;
+  for (auto _ : best::bounds{.count = 100}) {
+    strs[k].insert();
+    k.push('#');
+  }
+  best::eprintln("{}", strs.debug());
+  for (auto i : best::bounds{.count = 100 / 2}) {
+    strs[k[{.count = 2 * i}]].remove();
+  }
+  best::eprintln("{}", strs.debug());
+  for (auto i : best::bounds{.count = 100}) {
+    t.expect_eq(strs[k[{.count = i}]].is_occupied(), i % 2 != 0);
+  }
+};
+
+best::test HammerIntVec = [](auto& t) {
+  best::table<best::vec<int>> vecs;
+
+  best::vec<int> k;
+  for (auto i : best::bounds{.count = 100}) {
+    vecs[k].insert();
+    k.push(i);
+  }
+  best::eprintln("{}", vecs.debug());
+  for (auto i : best::bounds{.count = 100 / 2}) {
+    vecs[k[{.count = 2 * i}]].remove();
+  }
+  best::eprintln("{}", vecs.debug());
+  for (auto i : best::bounds{.count = 100}) {
+    t.expect_eq(vecs[k[{.count = i}]].is_occupied(), i % 2 != 0);
+  }
+};
+
+best::test IntOption = [](auto& t) {
+  best::table<best::option<int>, int> m = {
+
+  };
+};
+}  // namespace best::table_test

--- a/best/container/table_test.cc
+++ b/best/container/table_test.cc
@@ -189,7 +189,9 @@ best::test HammerStrings = [](auto& t) {
   best::table<best::strbuf> strs;
 
   best::strbuf k;
-  for (auto _ : best::bounds{.count = 100}) {
+  for (auto ignore : best::bounds{.count = 100}) {
+    (void)ignore;
+
     strs[k].insert();
     k.push('#');
   }

--- a/best/hash/BUILD
+++ b/best/hash/BUILD
@@ -1,0 +1,39 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+  name = "hash",
+  hdrs = [
+    "hash.h",
+    "internal/hash.h",
+  ],
+  deps = [
+    "//best/base:fwd",
+    "//best/base:ord",
+    "//best/meta:init",
+    "//best/meta/traits:types",
+  ],
+)
+
+cc_library(
+  name = "impls",
+  hdrs = ["impls.h"],
+  deps = [
+    ":hash",
+    "//best/memory:span",
+    "//best/meta:reflect",
+    "//best/text:str",
+  ],
+)
+
+
+cc_library(
+  name = "fxhash",
+  hdrs = ["fxhash.h"],
+  deps = [
+    ":hash",
+    "//best/math:bit",
+    "//best/math:int",
+    "//best/math:overflow",
+    "//best/memory:span",
+  ],
+)

--- a/best/hash/fxhash.h
+++ b/best/hash/fxhash.h
@@ -1,0 +1,128 @@
+
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_HASH_FXHASH_H_
+#define BEST_HASH_FXHASH_H_
+
+#include <cstring>
+
+#include "best/base/fwd.h"
+#include "best/math/bit.h"
+#include "best/math/int.h"
+#include "best/math/overflow.h"
+#include "best/memory/span.h"
+
+namespace best {
+/// # `best::fxhash`
+///
+/// An implementation of the "rustc hash", a variant of fxhash, a multiplicative
+/// hash originally developed for FireFox.
+///
+/// See https://github.com/rust-lang/rustc-hash.
+class fxhash final {
+ public:
+  using output = uint64_t;
+
+  constexpr fxhash() : state_(Seed) {}
+  explicit constexpr fxhash(uint64_t seed) : state_(seed) {}
+
+  template <best::is_int Int>
+  constexpr void write(Int value) {
+    write(static_cast<uint64_t>(value));
+  }
+
+  constexpr void write(uint64_t n) { state_ = (state_ + n) * K; }
+
+  constexpr void write(best::span<const char> bytes) {
+    auto n = bytes.size();
+    uint64_t x0 = Y0, x1 = Y1;  // Digits of pi.
+
+    auto p = bytes.data().raw();
+    if (n <= 16) {
+      if (n >= 8) {
+        x0 ^= load64(p);
+        x1 ^= load64(p + (n - 8));
+      } else if (n >= 4) {
+        x0 ^= load32(p);
+        x1 ^= load32(p + (n - 4));
+      } else if (n > 0) {
+        x0 ^= p[0];
+        x1 ^= p[n / 2];
+        x1 ^= uint64_t(p[n - 1]) << 8;
+      }
+    } else {
+      auto end = p + (n - 16);
+      while (p < end) {
+        auto x = load64(p);
+        auto y = load64(p + 8);
+        auto t = best::mul(x0 ^ x, Y2 ^ y).mix();
+        x0 = x1;
+        x1 = t;
+        p += 16;
+      }
+
+      x0 ^= load64(end);
+      x1 ^= load64(end + 8);
+    }
+
+    write(best::mul(x0, x1).mix() ^ n);
+  }
+
+  constexpr output finish() const { return best::rotate_left(state_, 26); }
+
+ private:
+  // A non-deterministic seed, which will vary per-process due to ASLR, but will
+  // at best vary per-build otherwise.
+  static const uint64_t Seed;
+
+  static constexpr uint64_t K = 0xf1357aea2e62a9c5;
+
+  // Digits of pi.
+  static constexpr uint64_t Y0 = 0x243f6a8885a308d3;
+  static constexpr uint64_t Y1 = 0x13198a2e03707344;
+  static constexpr uint64_t Y2 = 0xa4093822299f31d0;
+
+  constexpr uint32_t load32(const char* p) {
+    uint32_t value = 0;
+    if (std::is_constant_evaluated()) {
+      for (auto i = 0; i < 4; i++) { value |= uint32_t(p[i]) << (i * 8); }
+    } else {
+      memcpy(&value, p, 4);
+    }
+    return value;
+  }
+
+  constexpr uint64_t load64(const char* p) {
+    uint64_t value = 0;
+    if (std::is_constant_evaluated()) {
+      for (auto i = 0; i < 8; i++) { value |= uint64_t(p[i]) << (i * 8); }
+    } else {
+      memcpy(&value, p, 8);
+    }
+    return value;
+  }
+
+  uint64_t state_ = 0;
+};
+
+inline const uint64_t fxhash::Seed = reinterpret_cast<uintptr_t>(&Seed);
+}  // namespace best
+
+#endif  // BEST_HASH_FXHASH_H_

--- a/best/hash/hash.h
+++ b/best/hash/hash.h
@@ -1,0 +1,178 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_HASH_HASH_H_
+#define BEST_HASH_HASH_H_
+
+#include "best/base/fwd.h"
+#include "best/hash/internal/hash.h"
+#include "best/meta/init.h"
+#include "best/meta/traits/types.h"
+
+//! General hashing utilities for use with hash tables.
+//!
+//! A `best::hasher` represents an in-process hash operation, which is passed
+//! to hashing functions for writing data to. These "hashing functions" are
+//! FTADLEs of the form
+//!
+//!  template <best::hash_state State>
+//!  friend void BestHash(best::hasher<State> h, const T& value);
+//!
+//! where `T` is the type being made hashable. This function is automatically
+//! provided for all equality-comparable types in best. Reflectable types are
+//! automatically made hashable by hashing their fields.
+//!
+//! Implementing `BestHash()` only requires including this header; other headers
+//! provide the rest of the machinery.
+
+namespace best {
+/// # `best::hash_state`
+///
+/// An implementation of a hasher. Such types should not be used directly;
+/// instead, use `best::hasher`.
+///
+/// A hash state is a type that provides a member alias `output`,
+/// a member function `write(best::span<const char>)`, and a member function
+/// `finish()`.
+///
+/// A hash state may provide further overloads of `write()` for optimizing
+/// writing values of certain types, such as integers.
+template <typename H>
+concept hash_state =
+  requires(H& state, best::span<best::dependent<const char, H>> data) {
+    typename H::output;
+
+    { state.write(data) };
+    { state.finish() } -> best::same<typename H::output>;
+  };
+
+/// # `best::hash<S>`
+///
+/// The output of some `best::hasher`.
+template <best::hash_state State>
+using hash = State::output;
+
+/// # `best::transient`
+///
+/// A field tag which marks a field as "transient" and thus not relevant for
+/// hashing. Can be used to exclude fields from being hashed when using
+/// reflection-generated hash functions.
+struct transient_t final {};
+inline constexpr best::transient_t transient{};
+
+/// # `best::hasher`
+///
+/// A hasher calculates hashes of hashable values. Values should be written
+/// using `write()`, and the final state
+template <best::hash_state H>
+class hasher final {
+ public:
+  /// # `hasher::hasher(...)`
+  ///
+  /// Constructs a new hasher with the given arguments, which are forwarded
+  /// to `H`.
+  template <typename... Args>
+  explicit constexpr hasher(Args&&... args)
+    requires best::constructible<H, Args&&...>
+    : state_(BEST_FWD(args)...) {}
+
+  constexpr hasher() = default;
+  constexpr hasher(const hasher&) = default;
+  constexpr hasher& operator=(const hasher&) = default;
+  constexpr hasher(const hasher&&) = default;
+  constexpr hasher& operator=(const hasher&&) = default;
+
+  /// # `hasher::write(...)`
+  ///
+  /// Advances the state of the hasher by writing hashable values to it.
+  template <typename T>
+  hasher& write(const T& value) requires (
+    requires { best::lie<H>.write(value); } ||
+    requires { BestHash(*this, value); })
+  {
+    if constexpr (requires { state_.write(value); }) {
+      state_.write(value);
+    } else {
+      BestHash(*this, value);
+    }
+
+    return *this;
+  }
+  template <typename... T>
+  hasher& write(const T&... value)
+    requires (sizeof...(T) != 1 && requires { (write(value), ...); })
+  {
+    (write(value), ...);
+    return *this;
+  }
+
+  /// # `hasher::finish()`
+  ///
+  /// Completes a hashing operation, and returns the result.
+  best::hash<H> finish() { return state_.finish(); }
+
+ private:
+  H state_;
+};
+
+/// # `best::hashable`
+///
+/// A type which can be hashed, i.e, which provides BestHash.
+template <typename T>
+concept hashable =
+  best::is_void<T> ||
+  requires(
+    const T& v,
+    best::hasher<best::hash_internal::dummy<best::dependent<const char, T>>>&
+      h) { h.write(v); };
+
+/// # `best::hash_of`
+///
+/// Returns the hash of the given elements as if they were passed to
+/// a `best::hasher` in that order. The hash state used must be
+/// default-constructible.
+template <best::hash_state H, typename... Args>
+best::hash<H> hash_of(const Args&... args) {
+  return best::hasher<H>().write(args...).finish();
+}
+
+/// # `best::hash_identity`
+///
+/// A hash identity is a generalization of equality suitable for use with a
+/// hash table. It specifies an equality function between a key type and a
+/// query type, and a way to hash them, such that if two values are equal, then
+/// their hashes are also equal.
+///
+/// A specific type may be the hash identity for many possible combinations of
+/// K and Q. The only requirement is that satisfaction of this concept must be
+/// an equivalence relation on types, and the equality function must also be an
+/// equivalence relation in the expected way.
+template <typename Id, typename K, typename Q = K>
+concept hash_identity = requires(
+  const Id& id, const K& key, const Q& query,
+  best::hasher<best::hash_internal::dummy<best::dependent<const char, Id>>>&
+    h) {
+  { id.equal(key, query) } -> best::same<bool>;
+  { id.hash<K>(h, key) };
+  { id.hash<K>(h, query) };
+};
+
+}  // namespace best
+
+#endif  // BEST_HASH_HASH_H_

--- a/best/hash/impls.h
+++ b/best/hash/impls.h
@@ -1,0 +1,106 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_HASH_IMPLS_H_
+#define BEST_HASH_IMPLS_H_
+
+#include "best/hash/hash.h"
+#include "best/math/int.h"
+#include "best/memory/span.h"
+#include "best/meta/reflect.h"
+#include "best/meta/traits/arrays.h"
+#include "best/meta/traits/enums.h"
+
+//! Implementations of `BestHash` for built-in types.
+
+namespace best {
+/// # `best::default_identity`
+///
+/// The default identity, which uses `operator==` and ordinary hashing.
+struct default_identity final {
+  template <typename K, best::equatable<K> Q>
+  constexpr bool equal(const K& key, const Q& query) const {
+    return key == query;
+  }
+
+  template <typename K, best::hashable Q, best::hash_state H>
+  constexpr void hash(best::hasher<H>& h, const Q& query) const {
+    if constexpr (best::is_string<K>) {
+      // Need to deal with nul-terminated strings here.
+
+      using code = best::code<best::encoding_type<K>>;
+      using S = best::as_auto<Q>;
+      if constexpr (best::same<S, const code*>) {
+        h.write(best::span<const code>::from_nul(query));
+        return;
+      } else if constexpr (best::is_sized_array_of<S, code>) {
+        constexpr auto n = *best::static_size<S> - 1;
+        h.write(best::span<const code, n>(&query[0], n));
+        return;
+      }
+    }
+
+    h.write(query);
+  }
+};
+
+template <best::hash_state State>
+constexpr void BestHash(best::hasher<State>& h, bool value) {
+  h.write((char)value);
+}
+
+template <best::hash_state State, best::is_int Int>
+constexpr void BestHash(best::hasher<State>& h, Int value) {
+  h.write(best::span<Int>(&value, 1).as_bytes());
+}
+
+template <best::hash_state State>
+constexpr void BestHash(best::hasher<State>& h,
+                        const best::contiguous auto& value)
+  requires requires { h.write(best::span(value)[0]); }
+{
+  best::span sp = value;
+  if constexpr (best::bytes_internal::byte_comparable<
+                  best::data_type<decltype(sp)>>) {
+    h.write(sp.size(), sp.as_bytes());
+    return;
+  }
+
+  h.write(sp.size());
+  for (const auto& v : sp) { h.write(v); }
+}
+
+template <best::hash_state State>
+constexpr void BestHash(best::hasher<State>& h,
+                        const best::is_reflected_struct auto& value) {
+  best::reflect<decltype(value)>.each([&](auto field) {
+    if (!field.template tags<best::transient>().is_empty()) { return; }
+
+    h.write(value->*field);
+  });
+}
+
+template <best::hash_state State>
+constexpr void BestHash(best::hasher<State>& h,
+                        const best::is_enum auto& value) {
+  h.write(best::to_underlying(value));
+}
+}  // namespace best
+
+#endif  // BEST_HASH_IMPLS_H_

--- a/best/hash/internal/hash.h
+++ b/best/hash/internal/hash.h
@@ -1,0 +1,36 @@
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_HASH_INTERNAL_HASH_H_
+#define BEST_HASH_INTERNAL_HASH_H_
+
+#include "best/base/fwd.h"
+
+namespace best::hash_internal {
+// Dummy hash state for best::hashable.
+template <typename C>
+struct dummy final {
+  using output = uint64_t;
+
+  void write(best::span<C>);
+  output finish();
+};
+}  // namespace best::hash_internal
+
+#endif  // BEST_HASH_INTERNAL_HASH_H_

--- a/best/log/wtf.h
+++ b/best/log/wtf.h
@@ -20,6 +20,7 @@
 #ifndef BEST_LOG_WTF_H_
 #define BEST_LOG_WTF_H_
 
+#include "best/base/port.h"
 #include "best/text/format.h"
 #include "best/text/strbuf.h"
 
@@ -47,6 +48,34 @@ template <best::formattable... Args>
 
   crash_internal::die(templ.where(), write);
 }
+
+/// # `best::must()`
+///
+/// Crashes if `cond` is false. `cond` may be any type convertible to `bool`, or
+/// a callback that, when called with no arguments, produces a type convertible
+/// to `bool`.
+template <typename Truthy, best::formattable... Args>
+void must(Truthy&& cond, best::format_template<Args...> templ,
+          const Args&... args) {
+  if constexpr (requires { static_cast<bool>(BEST_FWD(cond)()); }) {
+    if (static_cast<bool>(BEST_FWD(cond)())) { return; }
+  } else if (static_cast<bool>(BEST_FWD(cond))) {
+    return;
+  }
+
+  best::wtf(templ, args...);
+}
+
+/// # `best::debug_must()`
+///
+/// Identical in all ways to `best::must()` except that it only checks the
+/// condition if `best::is_debug()` returns true.
+template <typename Truthy, best::formattable... Args>
+void debug_must(Truthy&& cond, best::format_template<Args...> templ,
+                const Args&... args) {
+  if (best::is_debug()) { best::must(BEST_FWD(cond), templ, args...); }
+}
+
 }  // namespace best
 
 #endif  // BEST_LOG_WTF_H_

--- a/best/math/bit.h
+++ b/best/math/bit.h
@@ -181,6 +181,15 @@ BEST_INLINE_ALWAYS constexpr Int next_pow2(Int x) {
   return (best::next_pow2_minus1(x) + best::overflow(1)).strict();
 }
 
+/// # `best::round_up_to_pow2()`
+///
+/// Rounds `x` to the next multiple of `pow2`. `pow2` must be a power of 2.
+template <best::is_unsigned Int>
+BEST_INLINE_ALWAYS constexpr Int round_up_to_pow2(Int x, Int pow2) {
+  auto mask = pow2 - 1;
+  return (x + mask) & ~mask;
+}
+
 /// # `best::bits_for()`
 ///
 /// Computes the number of bits needed to store every value from `0` to `x`,

--- a/best/math/overflow.h
+++ b/best/math/overflow.h
@@ -34,6 +34,48 @@ namespace best {
 template <best::is_int>
 struct overflow;
 
+/// # `best::mul`
+///
+/// Constructing a value of this type performs a full-width multiplication.
+///
+/// Multiplication without overflow produces a double-width value, a high and
+/// a low part. If the high part is zero (or, for signed integers, all ones),
+/// the product did not overflow.
+template <best::is_int Int>
+struct mul final {
+  constexpr mul(Int a, Int b) {
+    // There isn't an especially good intrinsic for this. For now, we just
+    // perform the operation in i128 and chop it back down.
+    if constexpr (best::is_signed<Int>) {
+      auto c = __int128(a) * __int128(b);
+      lo = (Int)(c);
+      hi = (Int)(c >> best::bits_of<Int>);
+    } else {
+      auto c = (unsigned __int128)(a) * (unsigned __int128)(b);
+      lo = (Int)(c);
+      hi = (Int)(c >> best::bits_of<Int>);
+    }
+  }
+
+  Int lo, hi;
+
+  // # `mul::overflowed()`
+  //
+  // Returns whether this operation overflowed.
+  constexpr bool overflowed() const {
+    return hi == 0 || (hi == -1 && best::is_signed<Int>);
+  }
+
+  // # `mul::mix()`
+  //
+  // Mixes the high and low results of this multiplication. Useful for writing
+  // non-cryptographic hashes.
+  constexpr Int mix() const { return lo ^ hi; }
+};
+
+template <best::is_int A, best::is_int B>
+mul(A, B) -> mul<common_int<A, B>>;
+
 /// # `best::div_t`
 ///
 /// The result of calling `best::div`: a quotient and a remainder.

--- a/best/memory/BUILD
+++ b/best/memory/BUILD
@@ -36,6 +36,7 @@ cc_library(
     "internal/bytes.h",
   ],
   deps = [
+    "//best/hash",
     "//best/container:option",
     "//best/container:result",
     "//best/iter",
@@ -59,7 +60,9 @@ cc_library(
     "internal/layout.h"
   ],
   deps = [
+    "//best/math:bit",
     "//best/base:unsafe",
+    "//best/hash",
     "//best/math:overflow",
     "//best/meta:ops",
     "//best/meta:tlist",

--- a/best/memory/internal/layout.h
+++ b/best/memory/internal/layout.h
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <cstdlib>
 
+#include "best/math/bit.h"
 #include "best/meta/tlist.h"
 #include "best/meta/traits/ptrs.h"
 
@@ -42,12 +43,7 @@ using to_object = best::devoid<
 ///
 /// This is guaranteed to be a power of 2.
 template <typename... Types>
-inline constexpr size_t align_of = [] {
-  size_t align = 1;
-  best::types<to_object<Types>...>.each(
-    [&]<typename T> { align = (align > alignof(T) ? align : alignof(T)); });
-  return align;
-}();
+inline constexpr size_t align_of = best::max(size_t{1}, alignof(to_object<Types>)...);
 
 /// Computes the size of a struct with the given member types.
 ///
@@ -57,21 +53,13 @@ template <typename... Types>
 inline constexpr size_t size_of = [] {
   if (sizeof...(Types) == 0) { return size_t{1}; }
 
-  size_t size = 0, align = 1;
-
-  auto align_to = [&size](size_t align) {
-    auto remainder = size % align;
-    if (remainder != 0) { size += align - remainder; }
-  };
-
+  size_t size = 0;
   best::types<to_object<Types>...>.each([&]<typename T> {
-    align_to(alignof(T));
-    align = (align > alignof(T) ? align : alignof(T));
+    size = best::round_up_to_pow2(size, alignof(T));
     size += sizeof(T);
   });
 
-  align_to(align);
-  return size;
+  return best::round_up_to_pow2(size, align_of<Types...>);
 }();
 
 /// Computes the size of a union with the given member types.
@@ -81,21 +69,10 @@ inline constexpr size_t size_of = [] {
 /// a size of 1.
 template <typename... Types>
 inline constexpr size_t size_of_union = [] {
-  if (sizeof...(Types) == 0) { return size_t{1}; }
+  if constexpr (sizeof...(Types) == 0) { return size_t{1}; }
 
-  size_t size = 0, align = 1;
-  auto align_to = [&](size_t align) {
-    auto remainder = size % align;
-    if (remainder != 0) { size += align - remainder; }
-  };
-
-  best::types<to_object<Types>...>.each([&]<typename T> {
-    align = (align > alignof(T) ? align : alignof(T));
-    size = (size > sizeof(T) ? size : sizeof(T));
-  });
-
-  align_to(align);
-  return size;
+  return best::round_up_to_pow2(best::max(0, sizeof(to_object<Types>)...),
+                                align_of<Types...>);
 }();
 }  // namespace best::layout_internal
 

--- a/best/memory/layout.h
+++ b/best/memory/layout.h
@@ -24,6 +24,8 @@
 #include <cstdlib>
 
 #include "best/base/unsafe.h"
+#include "best/hash/hash.h"
+#include "best/math/bit.h"
 #include "best/math/int.h"
 #include "best/math/overflow.h"
 #include "best/memory/internal/layout.h"
@@ -126,6 +128,48 @@ class layout final {
                   layout_internal::align_of<Members...>);
   }
 
+  /// # `layout::of_struct()`
+  ///
+  /// Appends several layouts together, as if by `layout::of_struct()`.
+  static constexpr layout of_struct(std::initializer_list<layout> layouts) {
+    size_t size = 0, align = 1;
+    for (auto layout : layouts) {
+      size = best::round_up_to_pow2(size, layout.align());
+      size += layout.size();
+      align = best::max(align, layout.align());
+    }
+    size = best::round_up_to_pow2(size, align);
+    return layout(unsafe("same impl as of_struct()"), size, align);
+  }
+
+  /// # `layout::of_struct()`
+  ///
+  /// Overlays several layouts together, as if by `layout::of_union()`.
+  static constexpr layout of_union(std::initializer_list<layout> layouts) {
+    size_t size = 0, align = 1;
+    for (auto layout : layouts) {
+      size = best::max(size, layout.size());
+      align = best::max(align, layout.align());
+    }
+    size = best::round_up_to_pow2(size, align);
+    return layout(unsafe("same impl as of_struct()"), size, align);
+  }
+
+  /// # `layout::repeat()`
+  ///
+  /// Appends several copies of this layout together, as if by
+  /// `layout::array()`.
+  constexpr layout repeat(size_t n) const {
+    auto [sz, of] = best::overflow(size()) * n;
+    if (of || sz > best::max_of<size_t>) {
+      best::crash_internal::crash(
+        "attempted to allocate more than max_of<size_t>/2 bytes");
+    }
+
+    return layout(unsafe("manifest from the bounds check above and align()"),
+                  sz, align());
+  }
+
   /// # `layout::size()`.
   ///
   /// The size, in bytes. This is always divisible by `align`.
@@ -150,6 +194,11 @@ class layout final {
     auto rec = fmt.record();
     rec.field("size", ly.size());
     rec.field("align", ly.align());
+  }
+
+  template <best::hash_state State>
+  constexpr friend void BestHash(best::hasher<State>& h, const layout& value) {
+    h.write(value.size(), value.align());
   }
 
  public:

--- a/best/memory/ptr.h
+++ b/best/memory/ptr.h
@@ -366,6 +366,21 @@ class ptr final {
     return (best::pointee<U>*)raw();
   }
 
+  /// # `ptr::skip()`
+  ///
+  /// Advances to a `U` stored after `count` `T`s. In other words, this
+  /// takes an array of type `T` with `count` elements, and skips past it to
+  /// an array of `U`s.
+  template <typename U>
+  constexpr best::ptr<U> skip(size_t count = 1, best::tlist<U> = {}) const
+    requires thin && best::ptr<U>::thin
+  {
+    auto end = offset(count);
+    return end.template cast<char>()
+      .offset(end.misalignment(best::align_of<U>))
+      .template cast<U>();
+  }
+
   /// # `ptr::to_addr()`, `ptr::from_addr()`
   ///
   /// Converts this pointer to/from a raw address.
@@ -373,6 +388,17 @@ class ptr final {
   static ptr from_addr(uintptr_t addr, metadata meta = {}) requires thin
   {
     return {reinterpret_cast<pointee*>(addr), BEST_MOVE(meta)};
+  }
+
+  /// # `ptr::misalignment()`
+  ///
+  /// Returns the byte offset from this pointer's address to the next address
+  /// aligned to `align`, which must be a power of two.
+  ptrdiff_t misalignment(size_t align) const {
+    auto addr = to_addr();
+    auto mask = align - 1;
+    auto next = (addr + mask) & ~mask;
+    return next - addr;
   }
 
   /// # `ptr::raw()`, `ptr::meta()`

--- a/best/memory/span.h
+++ b/best/memory/span.h
@@ -36,6 +36,7 @@
 #include "best/memory/internal/bytes.h"
 #include "best/meta/init.h"
 #include "best/meta/tlist.h"
+#include "best/meta/traits/quals.h"
 
 //! Data spans.
 //!
@@ -307,6 +308,20 @@ class span final {
   constexpr size_t size() const requires is_dynamic
   {
     return size_;
+  }
+
+  /// # `span::as_bytes()`
+  ///
+  /// Returns a `char`-typed span of the same size as this span (adjusted for
+  /// scaling by the size of `T`).
+  constexpr best::span<best::copy_quals<char, T>,
+                       is_static ? *n * sizeof(T) : n>
+  as_bytes() const {
+    if constexpr (is_static) {
+      return {data().cast(best::types<char>)};
+    } else {
+      return {data().cast(best::types<char>), size() * sizeof(T)};
+    }
   }
 
   /// # `span::is_empty()`
@@ -927,8 +942,7 @@ constexpr span<T, n> span<T, n>::from_nul(T* data) {
   }
 
   auto ptr = data;
-  while (*ptr++ != T{0})
-    ;
+  while (*ptr++ != T{0});
   return best::span(data, ptr - data - 1);
 }
 

--- a/best/meta/tlist.h
+++ b/best/meta/tlist.h
@@ -423,6 +423,8 @@ class tlist final {
   constexpr bool operator==(best::is_tlist auto) const;
   constexpr best::partial_ord operator<=>(best::is_tlist auto that) const;
 
+  constexpr friend void BestHash(auto& h, const tlist& value) {}
+
  private:
   template <typename...>
   friend class tlist;

--- a/best/meta/traits/BUILD
+++ b/best/meta/traits/BUILD
@@ -40,6 +40,14 @@ cc_library(
 )
 
 cc_library(
+  name = "pairs",
+  hdrs = ["pairs.h"],
+  deps = [
+    ":types",
+  ]
+)
+
+cc_library(
   name = "ptrs",
   hdrs = ["ptrs.h"],
   deps = [

--- a/best/meta/traits/arrays.h
+++ b/best/meta/traits/arrays.h
@@ -23,6 +23,7 @@
 #include <type_traits>
 
 #include "best/base/fwd.h"
+#include "best/meta/traits/ptrs.h"
 
 //! Type traits for array types.
 //!
@@ -60,6 +61,26 @@ concept is_sized_array = std::is_bounded_array_v<T>;
 /// Identifies a unsized array type, i.e. `T[]`.
 template <typename T>
 concept is_unsized_array = std::is_unbounded_array_v<T>;
+
+/// # `best::is_array`
+///
+/// Identifies an array type with a given element type.
+template <typename T, typename E>
+concept is_array_of = best::is_array<T> && best::same<E, best::un_array<T>>;
+
+/// # `best::is_sized_array_of`
+///
+/// Identifies a sized array type, i.e. `T[n]`, for some specific type T.
+template <typename T, typename E>
+concept is_sized_array_of =
+  best::is_sized_array<T> && best::same<E, best::un_array<T>>;
+
+/// # `best::is_unsized_array_of`
+///
+/// Identifies a unsized array type, i.e. `T[]`, for some specific type T.
+template <typename T, typename E>
+concept is_unsized_array_of =
+  best::is_unsized_array<T> && best::same<E, best::un_array<T>>;
 
 /// # `best::shape_of<T>`
 ///

--- a/best/meta/traits/empty.h
+++ b/best/meta/traits/empty.h
@@ -51,6 +51,8 @@ concept is_empty = best::is_void<T> || std::is_empty_v<T>;
 struct empty final {
   constexpr bool operator==(const empty& that) const = default;
   constexpr std::strong_ordering operator<=>(const empty& that) const = default;
+
+  constexpr friend void BestHash(auto& h, const auto& value) {}
 };
 
 /// # `best::devoid<T>`

--- a/best/meta/traits/internal/types.h
+++ b/best/meta/traits/internal/types.h
@@ -47,18 +47,16 @@ T&& lie = [] {
     "attempted to tell a best::lie: this value cannot be materialized");
 }();
 
-struct wax {};
-template <typename Sealed>
-concept sealed = requires(Sealed sealed) {
-  sealed(wax{});
-  +sealed;  // Ensure that the user isn't passing a generic lambda.
+template <typename T>
+struct wax final {
+  using type = T;
 };
 
-template <typename T, sealed auto sealed = [](wax) { return T{}; }>
-inline constexpr auto seal = sealed;
+template <typename Sealed>
+concept sealed = requires(Sealed sealed) { sealed(wax<void>{}); };
 
 template <sealed S>
-using unseal = decltype(S{}(wax{}));
+using unseal = decltype(S{}(wax<void>{}))::type;
 
 template <typename...>
 struct same {
@@ -82,5 +80,36 @@ struct same<A, B...> {
 };
 
 }  // namespace best::traits_internal
+
+// This symbol is carefully crafted to be very small when mangled but also
+// readable in gdb's demangler.
+// It looks something like this: `sealed::{lambda(auto:1)#3}`.
+//
+// Asking for the name of this type using `best::type_name` will produce
+// something like `(lambda at :1:1)`, which is what the `#line` directive below
+// is for.
+namespace sealed {
+// clang-format off
+template <typename T, auto sealed =
+#line 1 "" // This hides the identity of the lambda when Clang prints its name.
+[](auto x) 
+  requires best::traits_internal::same<
+    decltype(x),
+    best::traits_internal::wax<void>
+  >::value
+  {
+    return best::traits_internal::wax<T>{};
+  }
+>
+inline constexpr auto BEST_MAKE_SEAL_ = sealed;
+// clang-format on
+}  // namespace sealed
+
+namespace best::traits_internal {
+template <typename T>
+inline constexpr auto seal = sealed::BEST_MAKE_SEAL_<T>;
+}
+
+#define BEST_MAKE_SEAL_ _priv
 
 #endif  // BEST_META_TRAITS_INTERNAL_TYPES_H_

--- a/best/meta/traits/pairs.h
+++ b/best/meta/traits/pairs.h
@@ -1,0 +1,57 @@
+
+/* //-*- C++ -*-///////////////////////////////////////////////////////////// *\
+
+  Copyright 2024
+  Miguel Young de la Sota and the Best Contributors 🧶🐈‍⬛
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy
+  of the License at
+
+                https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+\* ////////////////////////////////////////////////////////////////////////// */
+
+#ifndef BEST_META_TRAITS_PAIRS_H_
+#define BEST_META_TRAITS_PAIRS_H_
+
+#include "best/meta/traits/types.h"
+
+//! Type traits for working with pair-like types.
+
+namespace best {
+/// # `best::is_pair`
+///
+/// Returns whether a type is pair-like, in that it can be destructured into
+/// exactly two elements using structured bindings.
+template <typename P>
+concept is_pair = requires {
+  {
+    [](P pair) { auto&& [a, b] = BEST_FWD(pair); }
+  };
+};
+
+/// # `best::first_in<P>`, `best::second_in<P>`
+///
+/// Returns the type of the first or second value in a pair, as defined by
+/// `best::is_pair`.
+template <best::is_pair P>
+using first_in = decltype([](auto&& pair) -> decltype(auto) {
+  auto&& [a, b] = BEST_FWD(pair);
+  return BEST_FWD(a);
+}(best::lie<P>));
+template <best::is_pair P>
+using second_in = decltype([](auto&& pair) -> decltype(auto) {
+  auto&& [a, b] = BEST_FWD(pair);
+  return BEST_FWD(b);
+}(best::lie<P>));
+
+}  // namespace best
+
+#endif  // BEST_META_TRAITS_PAIRS_H_

--- a/best/meta/traits/types.h
+++ b/best/meta/traits/types.h
@@ -127,9 +127,9 @@ using select_trait = traits_internal::select<cond, A, B>::type::type;
 /// This produces a new type with a very small opaque name that can be
 /// `best::unabridge`ed to produce the original type.
 template <typename T>
-using abridge = decltype(best::traits_internal::seal<best::id<T>>);
+using abridge = std::remove_const_t<decltype(best::traits_internal::seal<T>)>;
 template <typename T>
-using unabridge = best::traits_internal::unseal<T>::type;
+using unabridge = best::traits_internal::unseal<T>;
 
 /// # `best::abridged<T>`
 ///

--- a/best/test/test.h
+++ b/best/test/test.h
@@ -22,6 +22,7 @@
 
 #include "best/cli/cli.h"
 #include "best/log/location.h"
+#include "best/meta/init.h"
 #include "best/text/format.h"
 #include "best/text/str.h"
 
@@ -99,10 +100,12 @@ class test final {
   /// ```
   /// if (!t.expect(...)) { return; }
   /// ```
-  template <best::formattable... Args>
-  bool expect(bool cond, best::format_template<Args...> message = "",
+  template <typename Cond, best::formattable... Args>
+  requires best::constructible<bool, Cond&&>
+  bool expect(Cond&& cond, best::format_template<Args...> message = "",
               const Args&... args) {
-    if (!cond) {
+    bool c = static_cast<bool>(BEST_FWD(cond));
+    if (!c) {
       best::eprintln("failed expect() at {:?}", message.where());
       if (!message.as_str().is_empty()) {
         best::eprint("=> ");
@@ -110,7 +113,7 @@ class test final {
       }
       failed_ = true;
     }
-    return cond;
+    return c;
   }
 
   /// # `test::expect_eq()` et. al.

--- a/best/text/BUILD
+++ b/best/text/BUILD
@@ -15,6 +15,7 @@ cc_library(
   hdrs = ["rune.h"],
   deps = [
     ":encoding",
+    "//best/hash",
     "//best/log/internal:crash",
   ]
 )

--- a/best/text/format.h
+++ b/best/text/format.h
@@ -193,8 +193,7 @@ struct format_spec final {
         BestFmtQuery(query, best::as_raw_ptr<T>());
       }
       return query;
-    }
-    ();
+    }();
   };
 
   constexpr bool operator==(const format_spec&) const = default;
@@ -585,6 +584,17 @@ void eprintln(best::format_template<Args...> templ, const Args&... args) {
   result.push('\n');
   ::fwrite(result.data(), 1, result.size(), stderr);
 }
+
+namespace option_internal {
+// See the matching decl in result.h.
+struct fmt final {
+  template <typename... Args>
+  BEST_INLINE_SYNTHETIC static void wtf(Args&&... args) {
+    auto message = best::format(BEST_FWD(args)...);
+    best::crash_internal::crash("%.*s", message.size(), message.data());
+  }
+};
+}  // namespace option_internal
 
 namespace result_internal {
 // See the matching decl in result.h.

--- a/best/text/internal/format_impls.h
+++ b/best/text/internal/format_impls.h
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <type_traits>
 
+#include "best/math/int.h"
 #include "best/meta/reflect.h"
 #include "best/text/rune.h"
 #include "best/text/str.h"
@@ -145,15 +146,16 @@ void BestFmt(auto& fmt, best::is_int auto value) {
   if (negative) { value = -value; }
 
   // Construct the actual digits.
+  auto uvalue = best::to_unsigned(value);
   char buf[128];
   size_t count = 0;
   do {
-    rune r = *rune::from_digit(value % base, base);
+    rune r = *rune::from_digit(uvalue % base, base);
     if (uppercase) { r = r.to_ascii_upper(); }
 
     buf[128 - count++ - 1] = r;
-    value /= base;
-  } while (value != 0);
+    uvalue /= base;
+  } while (uvalue != 0);
 
   best::str digits(unsafe("all characters are ascii"),
                    best::span(buf + 128 - count, count));

--- a/best/text/rune.h
+++ b/best/text/rune.h
@@ -327,6 +327,11 @@ class rune final {
     query.uses_method = [](rune r) { return r == 'q'; };
   }
 
+  template <best::hash_state State>
+  constexpr friend void BestHash(best::hasher<State>& h, const rune& value) {
+    h.write(value.value_);
+  }
+
   // best::rune has a niche representation.
   constexpr explicit rune(niche) : value_(-1) {}
   constexpr bool operator==(niche) const { return value_ == -1; }


### PR DESCRIPTION
This change adds `best::table`, a Swisstable implementation providing both a map-like and set-like interface.

Also included are:
* `best::hash`, a generic hashing implementation, comparable to Rust's `Hash` trait.
* `best::fxhash`, an fxhash implementation using the above.
* `best/base/arch.h`, containing feature-test macros.
* `best::option::expect`, same as Rust.
* `best::must` and `best::debug_must`, for assertions.
* `best::layout` factories that take initializer lists, for dynamic layouts.
* `best::mul` for full-width multiplication.
* `best::abridge` symbol improvements.
* `best::round_up_to_pow2`, for rounding to a power of 2.
* `best::ptr::skip`, `best::ptr::misalignment`. 
* `best::span::as_bytes()`.
* `best::is_pair` for working with pair-like types.
* `best::prefetch_for_read` and `best::prefetch_for_write`, prefetch intrinsics.